### PR TITLE
Add landing page

### DIFF
--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -10,7 +10,6 @@ export function App() {
   return (
     <Routes>
       <Route path="/" element={<Landing />} />
-      <Route path="/" element={<Dashboard />} />
       <Route path="/game/create" element={<CreateGame />} />
       <Route path="/game/:gameId/lobby" element={<Lobby />} />
       <Route path="/game/:gameId/final-riddle" element={<FinalRiddlePage />} />

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Routes, Route } from 'react-router';
-
+import Landing from './host/pages/landing/Landing';
 import Dashboard from './host/pages/dashboard/Dashboard';
 import FinalRiddlePage from './host/pages/riddle/FinalRiddlePage';
 import CreateGame from './host/pages/create-game/CreateGame';
@@ -9,6 +9,7 @@ import Lobby from './host/pages/lobby/Lobby';
 export function App() {
   return (
     <Routes>
+      <Route path="/" element={<Landing />} />
       <Route path="/" element={<Dashboard />} />
       <Route path="/game/create" element={<CreateGame />} />
       <Route path="/game/:gameId/lobby" element={<Lobby />} />

--- a/imports/ui/host/pages/landing/Landing.jsx
+++ b/imports/ui/host/pages/landing/Landing.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useNavigate } from 'react-router';
+
+const Landing = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100 flex flex-col">
+      <header className="border-b border-gray-800 px-8 py-4 flex items-center justify-between">
+        <span className="text-red-500 font-bold text-xl tracking-widest uppercase">
+          ESCAPESNAP
+        </span>
+      </header>
+
+      <main className="flex-1 flex items-center justify-center px-8 py-12">
+        <div className="w-full max-w-2xl text-center">
+          <p className="text-xs text-red-500 tracking-widest mb-3">
+            INITIATE PROTOCOL
+          </p>
+          <h1 className="text-6xl font-bold tracking-widest uppercase text-gray-100 mb-6">
+            ESCAPESNAP
+          </h1>
+          <p className="text-sm text-gray-400 tracking-wide mb-12 max-w-md mx-auto leading-relaxed">
+            Turn your surroundings into an interactive escape room. Solve visual riddles, collect clues, and crack the final code — wherever you are.
+          </p>
+
+          <button
+            onClick={() => navigate('/game/create')}
+            className="bg-red-700 hover:bg-red-600 text-white text-sm tracking-widest uppercase px-12 py-4 transition-colors cursor-pointer"
+          >
+            CREATE NEW GAME
+          </button>
+
+          <p className="text-xs text-gray-600 tracking-widest mt-8">
+            HOST A SESSION · BEGIN MISSION
+          </p>
+        </div>
+      </main>
+
+      <footer className="border-t border-gray-800 px-8 py-4 text-center">
+        <p className="text-xs text-gray-600 tracking-widest">
+          ESCAPESNAP
+        </p>
+      </footer>
+    </div>
+  );
+};
+
+export default Landing;


### PR DESCRIPTION
## What does this PR do?
Adds a new landing page at the root URL (/) so users see a proper entry point instead of the placeholder Dashboard. Includes a "Create New Game" CTA that routes to /game/create. Styled to match the existing dark/red aesthetic from the create-game and lobby screens.

## Type of change
- [yes] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Config / setup

## How to test
Run meteor and visit http://localhost:3000
Confirm the landing page renders with the ESCAPESNAP heading, tagline, and "Create New Game" button
Click "Create New Game" → confirm it routes to /game/create

<img width="2940" height="1912" alt="Screenshot 2026-05-04 at 12 17 26 am" src="https://github.com/user-attachments/assets/7ddd96a1-d7c7-4a6f-939d-218ca0525f00" />

## Checklist
- [yes] Code runs locally with no errors
- [yes] Follows project folder structure
- [] No console.log left in code
- [] Lint passes (meteor npm run lint)
