### PR TITLE
Fix/sidebar

### DIFF
--- a/client/main.css
+++ b/client/main.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+@plugin "daisyui";

--- a/client/main.jsx
+++ b/client/main.jsx
@@ -4,7 +4,12 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import './main.css';
 import { App } from '../imports/ui/App';
+import { BrowserRouter } from 'react-router-dom';
 
 Meteor.startup(() => {
-  createRoot(document.getElementById('app')).render(<App />);
+  createRoot(document.getElementById('app')).render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  );
 });

--- a/imports/api/games/GamesCollection.js
+++ b/imports/api/games/GamesCollection.js
@@ -1,0 +1,3 @@
+import { Mongo } from 'meteor/mongo';
+
+export const Games = new Mongo.Collection('games');

--- a/imports/api/games/gamesMethods.js
+++ b/imports/api/games/gamesMethods.js
@@ -3,10 +3,13 @@ import { Games } from './GamesCollection';
 import { FINAL_RIDDLE } from '../../lib/finalRiddle';
 
 Meteor.methods({
-  async 'games.create'() {
+  async 'games.create'({ timerMinutes = 30, capacity = 4, difficulty = 'medium' } = {}) {
     return Games.insertAsync({
       status: 'lobby',
       createdAt: new Date(),
+      timerMinutes,
+      capacity,
+      difficulty,
       players: [
         { id: 'player1', name: 'Dylan', revealedLetters: ['M', '?', 'A'] },
       ],

--- a/imports/api/games/gamesMethods.js
+++ b/imports/api/games/gamesMethods.js
@@ -5,12 +5,23 @@ import { FINAL_RIDDLE } from '../../lib/finalRiddle';
 Meteor.methods({
   async 'games.create'() {
     return Games.insertAsync({
-      status: 'final_riddle',
+      status: 'lobby',
       createdAt: new Date(),
       players: [
         { id: 'player1', name: 'Dylan', revealedLetters: ['M', '?', 'A'] },
       ],
       finalRiddle: FINAL_RIDDLE,
+    });
+  },
+
+  // SCRUM-103
+  async 'games.start'(gameId) {
+    const game = await Games.findOneAsync(gameId);
+    if (!game) throw new Meteor.Error('not-found', 'Game not found');
+    if (game.status !== 'lobby')
+      throw new Meteor.Error('invalid-state', 'Game is not in lobby state');
+    await Games.updateAsync(gameId, {
+      $set: { status: 'in_progress', startedAt: new Date() },
     });
   },
 

--- a/imports/api/games/gamesMethods.js
+++ b/imports/api/games/gamesMethods.js
@@ -1,0 +1,38 @@
+import { Meteor } from 'meteor/meteor';
+import { Games } from './GamesCollection';
+import { FINAL_RIDDLE } from '../../lib/finalRiddle';
+
+Meteor.methods({
+  'games.create'() {
+    return Games.insert({
+      status: 'final_riddle',
+      createdAt: new Date(),
+      players: [
+        { id: 'player1', name: 'Dylan', revealedLetters: ['M', '?', 'A'] },
+
+      ],
+      finalRiddle: FINAL_RIDDLE,
+    });
+  },
+
+  // SCRUM-126, SCRUM-119
+  'games.submitFinalAnswer'(gameId, guess) {
+    const game = Games.findOne(gameId);
+    if (!game) throw new Meteor.Error('not-found', 'Game not found');
+    if (game.status !== 'final_riddle')
+      throw new Meteor.Error('invalid-state', 'Game is not in final riddle phase');
+
+    // Sprint 3: move answer validation server-side only so answer is never sent to client
+    const isCorrect =
+      guess.trim().toLowerCase() === game.finalRiddle.answer.toLowerCase();
+
+    Games.update(gameId, {
+      $set: {
+        status: isCorrect ? 'won' : 'lost',
+        endedAt: new Date(),
+      },
+    });
+
+    return isCorrect;
+  },
+});

--- a/imports/api/games/gamesMethods.js
+++ b/imports/api/games/gamesMethods.js
@@ -3,21 +3,20 @@ import { Games } from './GamesCollection';
 import { FINAL_RIDDLE } from '../../lib/finalRiddle';
 
 Meteor.methods({
-  'games.create'() {
-    return Games.insert({
+  async 'games.create'() {
+    return Games.insertAsync({
       status: 'final_riddle',
       createdAt: new Date(),
       players: [
         { id: 'player1', name: 'Dylan', revealedLetters: ['M', '?', 'A'] },
-
       ],
       finalRiddle: FINAL_RIDDLE,
     });
   },
 
   // SCRUM-126, SCRUM-119
-  'games.submitFinalAnswer'(gameId, guess) {
-    const game = Games.findOne(gameId);
+  async 'games.submitFinalAnswer'(gameId, guess) {
+    const game = await Games.findOneAsync(gameId);
     if (!game) throw new Meteor.Error('not-found', 'Game not found');
     if (game.status !== 'final_riddle')
       throw new Meteor.Error('invalid-state', 'Game is not in final riddle phase');
@@ -26,9 +25,9 @@ Meteor.methods({
     const isCorrect =
       guess.trim().toLowerCase() === game.finalRiddle.answer.toLowerCase();
 
-    Games.update(gameId, {
+    await Games.updateAsync(gameId, {
       $set: {
-        status: isCorrect ? 'won' : 'lost',
+        // status: isCorrect ? 'won' : 'lost',
         endedAt: new Date(),
       },
     });

--- a/imports/api/games/gamesPublications.js
+++ b/imports/api/games/gamesPublications.js
@@ -1,0 +1,6 @@
+import { Meteor } from 'meteor/meteor';
+import { Games } from './GamesCollection';
+
+Meteor.publish('games.current', function (status) {
+  return Games.find({ status: status });
+});

--- a/imports/api/games/gamesPublications.js
+++ b/imports/api/games/gamesPublications.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { Games } from './GamesCollection';
 
-Meteor.publish('games.current', function (status) {
-  return Games.find({ status: status });
+Meteor.publish('games.current', function (gameId) {
+  return Games.find({ _id: gameId });
 });

--- a/imports/lib/finalRiddle.js
+++ b/imports/lib/finalRiddle.js
@@ -1,6 +1,6 @@
 // Sprint 3: replace with AI-generated riddle fetched from server
 export const FINAL_RIDDLE = {
   riddle:
-    'I have cities, but no houses live there. I have mountains, but no trees grow there. I have water, but no fish swim there. I have roads, but no cars drive there. What am I?',
+    'I have cities, but no houses live there. I have mountains, but no trees grow there. I have water, but no fish swim there. I have roads, but no cars drive there. I have cities, but no houses live there. I have mountains, but no trees grow there. I have water, but no fish swim there. I have roads, but no cars drive there.I have cities, but no houses live there. I have mountains, but no trees grow there. I have water, but no fish swim there. I have roads, but no cars drive there. What am I?',
   answer: 'map',
 };

--- a/imports/lib/finalRiddle.js
+++ b/imports/lib/finalRiddle.js
@@ -1,0 +1,6 @@
+// Sprint 3: replace with AI-generated riddle fetched from server
+export const FINAL_RIDDLE = {
+  riddle:
+    'I have cities, but no houses live there. I have mountains, but no trees grow there. I have water, but no fish swim there. I have roads, but no cars drive there. What am I?',
+  answer: 'map',
+};

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -10,7 +10,6 @@ export function App() {
   return (
     <Routes>
       <Route path="/" element={<Landing />} />
-      <Route path="/" element={<Dashboard />} />
       <Route path="/game/create" element={<CreateGame />} />
       <Route path="/game/:gameId/lobby" element={<Lobby />} />
       <Route path="/game/:gameId/final-riddle" element={<FinalRiddlePage />} />

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Routes, Route } from 'react-router';
-
+import Landing from './host/pages/landing/Landing';
 import Dashboard from './host/pages/dashboard/Dashboard';
 import FinalRiddlePage from './host/pages/riddle/FinalRiddlePage';
 import CreateGame from './host/pages/create-game/CreateGame';
@@ -9,6 +9,7 @@ import Lobby from './host/pages/lobby/Lobby';
 export function App() {
   return (
     <Routes>
+      <Route path="/" element={<Landing />} />
       <Route path="/" element={<Dashboard />} />
       <Route path="/game/create" element={<CreateGame />} />
       <Route path="/game/:gameId/lobby" element={<Lobby />} />

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -3,11 +3,13 @@ import { Routes, Route } from 'react-router';
 
 import Dashboard from './host/pages/dashboard/Dashboard';
 import FinalRiddlePage from './host/pages/riddle/FinalRiddlePage';
+import CreateGame from './host/pages/create-game/CreateGame';
 
 export function App() {
   return (
     <Routes>
       <Route path="/" element={<Dashboard />} />
+      <Route path="/game/create" element={<CreateGame />} />
       <Route path="/game/:gameId/final-riddle" element={<FinalRiddlePage />} />
     </Routes>
   );

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import { Routes, Route } from 'react-router';
+
+import Dashboard from './host/pages/dashboard/Dashboard';
+import FinalRiddlePage from './host/pages/riddle/FinalRiddlePage';
 
 export function App() {
   return (
-    <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center">
-      <h1 className="text-4xl font-bold">EscapeSnap</h1>
-    </div>
+    <Routes>
+      <Route path="/" element={<Dashboard />} />
+      <Route path="/game/:gameId/final-riddle" element={<FinalRiddlePage />} />
+    </Routes>
   );
 }

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -4,12 +4,14 @@ import { Routes, Route } from 'react-router';
 import Dashboard from './host/pages/dashboard/Dashboard';
 import FinalRiddlePage from './host/pages/riddle/FinalRiddlePage';
 import CreateGame from './host/pages/create-game/CreateGame';
+import Lobby from './host/pages/lobby/Lobby';
 
 export function App() {
   return (
     <Routes>
       <Route path="/" element={<Dashboard />} />
       <Route path="/game/create" element={<CreateGame />} />
+      <Route path="/game/:gameId/lobby" element={<Lobby />} />
       <Route path="/game/:gameId/final-riddle" element={<FinalRiddlePage />} />
     </Routes>
   );

--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -5,6 +5,7 @@ import Dashboard from './host/pages/dashboard/Dashboard';
 import FinalRiddlePage from './host/pages/riddle/FinalRiddlePage';
 import CreateGame from './host/pages/create-game/CreateGame';
 import Lobby from './host/pages/lobby/Lobby';
+import ProgressPage from './host/pages/progress/ProgressPage';
 
 export function App() {
   return (
@@ -12,6 +13,7 @@ export function App() {
       <Route path="/" element={<Dashboard />} />
       <Route path="/game/create" element={<CreateGame />} />
       <Route path="/game/:gameId/lobby" element={<Lobby />} />
+      <Route path="/game/:gameId/progress" element={<ProgressPage />} />
       <Route path="/game/:gameId/final-riddle" element={<FinalRiddlePage />} />
     </Routes>
   );

--- a/imports/ui/host/components/riddle/FinalRiddle.jsx
+++ b/imports/ui/host/components/riddle/FinalRiddle.jsx
@@ -4,7 +4,7 @@ const FinalRiddle = ({ finalRiddle }) => {
   return (
     <div className="bg-gray-900 py-6 px-12 mx-8 my-8">
       <div className='flex justify-content items-center mt-6 mb-6'>
-        <h2 className="text-white font-extrabold text-7xl uppercase tracking-widest mb-1 mx-2">
+        <h2 className="text-white font-extraitalic text-7xl uppercase tracking-widest mb-4 mx-2">
             THE FINAL
         </h2>
         <h2 className='text-red-600 font-extrabold text-7xl uppercase tracking-widest mb-1 px-4'> 

--- a/imports/ui/host/components/riddle/FinalRiddle.jsx
+++ b/imports/ui/host/components/riddle/FinalRiddle.jsx
@@ -11,7 +11,7 @@ const FinalRiddle = ({ finalRiddle }) => {
             Riddle 
         </h2>
       </div>
-      <div className="bg-gray-800 border-l-8 border-red-600 p-2 mb-1">
+      <div className="bg-gray-800 border-l-8 border-red-600 p-12 mb-2">
         <p className="text-white font-extrabold text-2xl tracking-wide">{"\"" + finalRiddle + "\""}</p>
       </div>
     </div>

--- a/imports/ui/host/components/riddle/FinalRiddle.jsx
+++ b/imports/ui/host/components/riddle/FinalRiddle.jsx
@@ -4,14 +4,14 @@ const FinalRiddle = ({ finalRiddle }) => {
   return (
     <div className="bg-gray-900 py-6 px-12 mx-8 my-8">
       <div className='flex justify-content items-center mt-6 mb-6'>
-        <h2 className="text-white-600 font-extraitalic text-7xl uppercase mb-6 mx-2">
-            The Final
-        </h2> 
-        <h2 className='text-red-600 font-extrabold text-7xl uppercase tracking-widest mb-6 px-4'> 
+        <h2 className="text-white font-extrabold text-7xl uppercase tracking-widest mb-1 mx-2">
+            THE FINAL
+        </h2>
+        <h2 className='text-red-600 font-extrabold text-7xl uppercase tracking-widest mb-1 px-4'> 
             Riddle 
         </h2>
       </div>
-      <div className="bg-gray-800 border-l-8 border-red-600 p-12 mb-20">
+      <div className="bg-gray-800 border-l-8 border-red-600 p-2 mb-1">
         <p className="text-white font-extrabold text-2xl tracking-wide">{"\"" + finalRiddle + "\""}</p>
       </div>
     </div>

--- a/imports/ui/host/components/riddle/FinalRiddle.jsx
+++ b/imports/ui/host/components/riddle/FinalRiddle.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const FinalRiddle = ({ finalRiddle }) => {
+  return (
+    <div className="bg-gray-900 py-6 px-12 mx-8 my-8">
+      <div className='flex justify-content items-center mt-6 mb-6'>
+        <h2 className="text-white-600 font-extraitalic text-7xl uppercase mb-6 mx-2">
+            The Final
+        </h2> 
+        <h2 className='text-red-600 font-extrabold text-7xl uppercase tracking-widest mb-6 px-4'> 
+            Riddle 
+        </h2>
+      </div>
+      <div className="bg-gray-800 border-l-8 border-red-600 p-12 mb-20">
+        <p className="text-white font-extrabold text-2xl tracking-wide">{"\"" + finalRiddle + "\""}</p>
+      </div>
+    </div>
+  );
+};
+
+export default FinalRiddle;

--- a/imports/ui/host/components/riddle/FinalRiddleInput.jsx
+++ b/imports/ui/host/components/riddle/FinalRiddleInput.jsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+import { Meteor } from 'meteor/meteor';
+
+const FinalRiddleInput = ({ gameId }) => {
+  const [guess, setGuess] = useState('');
+  const [result, setResult] = useState(null); // 'correct' | 'incorrect' | null
+
+  useEffect(() => {
+    if (!result) return;
+    const timer = setTimeout(() => setResult(null), 3000);
+    return () => clearTimeout(timer);
+  }, [result]);
+
+  function handleSubmit() {
+    Meteor.call('games.submitFinalAnswer', gameId, guess, (error, isCorrect) => {
+      if (error) {
+        console.error(error);
+        return;
+      }
+      setResult(isCorrect ? 'correct' : 'incorrect');
+    });
+  }
+
+  return (
+    <div className='min-w-screen px-20'>
+      <input
+        type="text"
+        placeholder="Input riddle guess..."
+        className="w-full bg-gray-900 border-gray-200 min-h-22 input input-lg text-gray-500 text-2xl font-extraitalic"
+        onChange={e => setGuess(e.target.value)}
+      />
+      <button
+        className="w-full min-h-22 btn bg-red-600 mt-15 font-italic text-2xl"
+        onClick={handleSubmit}
+      >
+        Make Guess
+      </button>
+
+      {result === 'correct' && (
+        <div className="toast toast-center toast-middle">
+          <div className="alert alert-success">
+            <span>YOU WIN!!!!</span>
+          </div>
+        </div>
+      )}
+      {result === 'incorrect' && (
+        <div className="toast toast-center toast-middle">
+          <div className="alert alert-error">
+            <span>Incorrect Guess.</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FinalRiddleInput;

--- a/imports/ui/host/components/riddle/FinalRiddleInput.jsx
+++ b/imports/ui/host/components/riddle/FinalRiddleInput.jsx
@@ -23,15 +23,15 @@ const FinalRiddleInput = ({ gameId, onCorrect = () => {} }) => {
   }
 
   return (
-    <div className='min-w-screen px-20'>
+    <div className='min-w-screen px-12'>
       <input
         type="text"
         placeholder="Input riddle guess..."
-        className="w-full bg-gray-900 border-gray-200 min-h-22 input input-lg text-gray-500 text-2xl font-extraitalic"
+        className="w-full bg-gray-900 border-gray-200 min-h-15 input input-lg text-gray-500 text-2xl font-extraitalic"
         onChange={e => setGuess(e.target.value)}
       />
       <button
-        className="w-full min-h-22 btn bg-red-600 mt-15 font-italic text-2xl"
+        className="w-full min-h-15 btn bg-red-600 mt-1 font-italic text-2xl"
         onClick={handleSubmit}
       >
         Make Guess

--- a/imports/ui/host/components/riddle/FinalRiddleInput.jsx
+++ b/imports/ui/host/components/riddle/FinalRiddleInput.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Meteor } from 'meteor/meteor';
 
-const FinalRiddleInput = ({ gameId }) => {
+const FinalRiddleInput = ({ gameId, onCorrect = () => {} }) => {
   const [guess, setGuess] = useState('');
-  const [result, setResult] = useState(null); // 'correct' | 'incorrect' | null
+  const [result, setResult] = useState(null);
 
   useEffect(() => {
     if (!result) return;
@@ -18,6 +18,7 @@ const FinalRiddleInput = ({ gameId }) => {
         return;
       }
       setResult(isCorrect ? 'correct' : 'incorrect');
+      if (isCorrect) onCorrect();
     });
   }
 
@@ -36,13 +37,6 @@ const FinalRiddleInput = ({ gameId }) => {
         Make Guess
       </button>
 
-      {result === 'correct' && (
-        <div className="toast toast-center toast-middle">
-          <div className="alert alert-success">
-            <span>YOU WIN!!!!</span>
-          </div>
-        </div>
-      )}
       {result === 'incorrect' && (
         <div className="toast toast-center toast-middle">
           <div className="alert alert-error">

--- a/imports/ui/host/components/riddle/FinalRiddleInput.jsx
+++ b/imports/ui/host/components/riddle/FinalRiddleInput.jsx
@@ -23,25 +23,48 @@ const FinalRiddleInput = ({ gameId, onCorrect = () => {} }) => {
   }
 
   return (
-    <div className='min-w-screen px-12'>
+    <div className="flex flex-col gap-3">
       <input
         type="text"
-        placeholder="Input riddle guess..."
-        className="w-full bg-gray-900 border-gray-200 min-h-15 input input-lg text-gray-500 text-2xl font-extraitalic"
+        placeholder="TYPE YOUR ANSWER..."
+        value={guess}
         onChange={e => setGuess(e.target.value)}
+        onKeyDown={e => e.key === 'Enter' && handleSubmit()}
+        style={{
+          width: '100%',
+          background: '#131313',
+          border: '1px solid #353534',
+          padding: '14px 16px',
+          color: '#e5e2e1',
+          fontSize: 14,
+          letterSpacing: '1px',
+          outline: 'none',
+          fontFamily: "'Space Grotesk', Helvetica, sans-serif",
+        }}
       />
       <button
-        className="w-full min-h-15 btn bg-red-600 mt-1 font-italic text-2xl"
         onClick={handleSubmit}
+        style={{
+          width: '100%',
+          padding: '14px',
+          background: '#8b0000',
+          color: '#e5e2e1',
+          fontWeight: 700,
+          fontSize: 13,
+          letterSpacing: '1.5px',
+          cursor: 'pointer',
+          transition: 'background 0.15s',
+          fontFamily: "'Space Grotesk', Helvetica, sans-serif",
+        }}
+        onMouseEnter={e => (e.currentTarget.style.background = '#a50000')}
+        onMouseLeave={e => (e.currentTarget.style.background = '#8b0000')}
       >
-        Make Guess
+        SUBMIT ANSWER
       </button>
 
       {result === 'incorrect' && (
-        <div className="toast toast-center toast-middle">
-          <div className="alert alert-error">
-            <span>Incorrect Guess.</span>
-          </div>
+        <div style={{ padding: '12px 16px', background: '#1c0000', borderLeft: '3px solid #8b0000' }}>
+          <p style={{ fontSize: 12, color: '#ffdad6', letterSpacing: '1px' }}>INCORRECT - TRY AGAIN</p>
         </div>
       )}
     </div>

--- a/imports/ui/host/components/riddle/RevealedLetters.jsx
+++ b/imports/ui/host/components/riddle/RevealedLetters.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const RevealedLetters = ({ letters }) => {
   return (
-    <div className="flex flex-wrap justify-center gap-2 my-100">
+    <div className="flex flex-wrap justify-center gap-2 my-10">
       {letters.map((letter, index) => (
 
       

--- a/imports/ui/host/components/riddle/RevealedLetters.jsx
+++ b/imports/ui/host/components/riddle/RevealedLetters.jsx
@@ -6,9 +6,9 @@ const RevealedLetters = ({ letters }) => {
       {letters.map((letter, index) => (
 
       
-        <div className="hover-3d">
+        <div key={index}  className="hover-3d">
         {/* content */}
-        <div key={index} className="w-24 h-24 flex items-center justify-center border-b-2 border-red-600 bg-gray-600 text-white font-bold text-2xl uppercase tracking-widest">
+        <div className="w-24 h-24 flex items-center justify-center border-b-2 border-red-600 bg-gray-600 text-white font-bold text-2xl uppercase tracking-widest">
           {letter}
         </div>
         {/* 8 empty divs needed for the 3D effect */}

--- a/imports/ui/host/components/riddle/RevealedLetters.jsx
+++ b/imports/ui/host/components/riddle/RevealedLetters.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const RevealedLetters = ({ letters }) => {
+  return (
+    <div className="flex flex-wrap justify-center gap-2 my-100">
+      {letters.map((letter, index) => (
+
+      
+        <div className="hover-3d">
+        {/* content */}
+        <div key={index} className="w-24 h-24 flex items-center justify-center border-b-2 border-red-600 bg-gray-600 text-white font-bold text-2xl uppercase tracking-widest">
+          {letter}
+        </div>
+        {/* 8 empty divs needed for the 3D effect */}
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+        </div>
+
+      ))}
+    </div>
+  );
+};
+
+export default RevealedLetters;

--- a/imports/ui/host/components/riddle/RevealedLetters.jsx
+++ b/imports/ui/host/components/riddle/RevealedLetters.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 
 const RevealedLetters = ({ letters }) => {
   return (
-    <div className="flex flex-wrap justify-center gap-2 my-10">
+    <div className="flex flex-wrap justify-center gap-2 mt-10 mb-16">
       {letters.map((letter, index) => (
 
       
         <div key={index}  className="hover-3d">
         {/* content */}
-        <div className="w-24 h-24 flex items-center justify-center border-b-2 border-red-600 bg-gray-600 text-white font-bold text-2xl uppercase tracking-widest">
-          {letter}
+        <div className="w-28 h-28 flex items-center justify-center border-b-2 border-red-600 bg-gray-600 text-white font-bold text-2xl uppercase tracking-widest">
+          {letter} 
         </div>
         {/* 8 empty divs needed for the 3D effect */}
         <div></div>

--- a/imports/ui/host/pages/create-game/CreateGame.jsx
+++ b/imports/ui/host/pages/create-game/CreateGame.jsx
@@ -1,11 +1,159 @@
-import React from 'react'
+import React, { useState } from 'react';
+import { Meteor } from 'meteor/meteor';
+import { useNavigate } from 'react-router';
+
+const DIFFICULTY_OPTIONS = [
+  { value: 'easy', label: 'EASY', sub: 'STABLE VITALS' },
+  { value: 'medium', label: 'MEDIUM', sub: 'ELEVATED CORTISOL' },
+  { value: 'hard', label: 'HARD', sub: 'SYSTEMIC FAILURE' },
+];
 
 const CreateGame = () => {
-  return (
-    <div>
-      GAME CREATION PAGE
-    </div>
-  )
-}
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
-export default CreateGame
+  const [timer, setTimer] = useState(30);
+  const [capacity, setCapacity] = useState(4);
+  const [difficulty, setDifficulty] = useState('medium');
+
+  const handleCreateGame = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const gameId = await Meteor.callAsync('games.create');
+      navigate(`/game/${gameId}/final-riddle`);
+    } catch (err) {
+      setError(err.reason || err.message || 'INITIALIZATION FAILED');
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100 flex flex-col">
+      <header className="border-b border-gray-800 px-8 py-4 flex items-center justify-between">
+        <span className="text-red-500 font-bold text-xl tracking-widest uppercase">
+          ESCAPESNAP
+        </span>
+      </header>
+
+      <main className="flex-1 flex items-center justify-center px-8 py-12">
+        <div className="w-full max-w-lg">
+          <div className="mb-8">
+            <p className="font-BOLD text-xs text-red-500 tracking-widest mb-1">
+              CREATE A NEW GAME
+            </p>
+            <h1 className="text-3xl font-bold tracking-widest uppercase text-gray-100">
+              GAME CONFIGURATION
+            </h1>
+            <p className="text-xs text-gray-500 mt-2 tracking-wide">
+              DEFINE GAME PARAMETERS BEFORE ENTERING
+            </p>
+          </div>
+
+          <div className="space-y-6">
+
+            <div className="border border-gray-800 p-4">
+              <label className="block text-xs text-gray-400 tracking-widest mb-3">
+                GAME TIME LIMIT (MIN)
+              </label>
+              <div className="">
+                <input type="range" min={10} max={60} step={5} value={timer} className="range w-full text-gray-400" onChange={e => setTimer(Number(e.target.value))}/>
+                <div className="flex justify-between px-2.5 mt-2 text-xs">
+                    <span>|</span>
+                    <span>|</span>
+                    <span>|</span>
+                    <span>|</span>
+                    <span>|</span>
+                    <span>|</span>
+                    <span>|</span>
+                    <span>|</span>
+                    <span>|</span>
+                    <span>|</span>
+                    <span>|</span>
+
+                </div>
+                <div className="flex justify-between px-2.5 mt-2 text-xs">
+                    <span>10</span>
+                    <span>15</span>
+                    <span>20</span>
+                    <span>25</span>
+                    <span>30</span>
+                    <span>35</span>
+                    <span>40</span>
+                    <span>45</span>
+                    <span>50</span>
+                    <span>55</span>
+                    <span>60</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="border border-gray-800 p-4">
+              <label className="block text-xs text-gray-400 tracking-widest mb-3">
+                LOBBY CAPACITY
+              </label>
+              <div className="flex items-center gap-4">
+                <input type="range" min={1} max={8} step={1} value={capacity} onChange={e => setCapacity(Number(e.target.value))} className="range flex-1 text-gray-400"
+                />
+                <span className="text-red-400 text-lg w-12 text-right">
+                  {String(capacity).padStart(2, '0')}
+                </span>
+              </div>
+            </div>
+
+            <div className="border border-gray-800 p-4">
+              <label className="block text-xs text-gray-400 tracking-widest mb-3">
+                DIFFICULTY LEVEL
+              </label>
+              <div className="grid grid-cols-3 gap-2">
+                {DIFFICULTY_OPTIONS.map(opt => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setDifficulty(opt.value)}
+                    className={`border p-3 text-left transition-colors cursor-pointer ${
+                      difficulty === opt.value
+                        ? 'border-red-500 bg-red-950'
+                        : 'border-gray-700 hover:border-gray-500'
+                    }`}
+                  >
+                    <div className="text-xs font-bold text-gray-100">
+                      {opt.label}
+                    </div>
+                    <div className="text-xs text-gray-500 mt-1 leading-tight">
+                      {opt.sub}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="border border-gray-800 p-3">
+              <p className="text-xs text-gray-600 tracking-wide">
+                SPRINT_1 // PRESET PLAYER: DYLAN ·
+                STATUS WILL BE SET TO{' '}
+                <span className="text-gray-500">FINAL_RIDDLE</span>
+              </p>
+            </div>
+
+            {error && (
+              <p className="text-xs text-red-500 tracking-widest">
+                !! {error}
+              </p>
+            )}
+
+            <button
+              onClick={handleCreateGame}
+              disabled={loading}
+              className="w-full bg-red-700 hover:bg-red-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-sm tracking-widest uppercase py-4 transition-colors cursor-pointer disabled:cursor-not-allowed"
+            >
+              {loading ? 'INITIALIZING…' : 'INITIALIZE MISSION'}
+            </button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default CreateGame;

--- a/imports/ui/host/pages/create-game/CreateGame.jsx
+++ b/imports/ui/host/pages/create-game/CreateGame.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const CreateGame = () => {
+  return (
+    <div>
+      GAME CREATION PAGE
+    </div>
+  )
+}
+
+export default CreateGame

--- a/imports/ui/host/pages/create-game/CreateGame.jsx
+++ b/imports/ui/host/pages/create-game/CreateGame.jsx
@@ -22,7 +22,7 @@ const CreateGame = () => {
     setError(null);
     try {
       const gameId = await Meteor.callAsync('games.create');
-      navigate(`/game/${gameId}/final-riddle`);
+      navigate(`/game/${gameId}/lobby`);
     } catch (err) {
       setError(err.reason || err.message || 'INITIALIZATION FAILED');
       setLoading(false);
@@ -132,7 +132,7 @@ const CreateGame = () => {
               <p className="text-xs text-gray-600 tracking-wide">
                 SPRINT_1 // PRESET PLAYER: DYLAN ·
                 STATUS WILL BE SET TO{' '}
-                <span className="text-gray-500">FINAL_RIDDLE</span>
+                <span className="text-gray-500">LOBBY</span>
               </p>
             </div>
 

--- a/imports/ui/host/pages/create-game/CreateGame.jsx
+++ b/imports/ui/host/pages/create-game/CreateGame.jsx
@@ -21,7 +21,7 @@ const CreateGame = () => {
     setLoading(true);
     setError(null);
     try {
-      const gameId = await Meteor.callAsync('games.create');
+      const gameId = await Meteor.callAsync('games.create', { timerMinutes: timer, capacity, difficulty });
       navigate(`/game/${gameId}/lobby`);
     } catch (err) {
       setError(err.reason || err.message || 'INITIALIZATION FAILED');

--- a/imports/ui/host/pages/dashboard/Dashboard.jsx
+++ b/imports/ui/host/pages/dashboard/Dashboard.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const Dashboard = () => {
+  return (
+    <div>
+      THIS IS THE DASHBOARD!!!
+    </div>
+  )
+}
+
+export default Dashboard

--- a/imports/ui/host/pages/game-completion/WinScreen.jsx
+++ b/imports/ui/host/pages/game-completion/WinScreen.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const WinScreen = ({ onPlayAgain }) => {
+  return (
+    <div className='min-h-screen bg-gray-900 flex flex-col items-center justify-center'>
+      <h1 className='text-red-600 font-extrabold text-7xl uppercase tracking-widest mb-4'>
+        You Escaped!
+      </h1>
+      <p className='text-white text-2xl font-extraitalic mb-12'>
+        The riddle has been solved.
+      </p>
+       {/* TODO: onPlayAgain should navigate to lobby screen once implemented */}
+      <button
+        className='btn bg-red-600 text-white text-2xl px-12 min-h-16'
+        onClick={onPlayAgain}
+      >
+        Play Again
+      </button>
+    </div>
+  );
+};
+
+export default WinScreen;

--- a/imports/ui/host/pages/landing/Landing.jsx
+++ b/imports/ui/host/pages/landing/Landing.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useNavigate } from 'react-router';
+
+const Landing = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100 flex flex-col">
+      <header className="border-b border-gray-800 px-8 py-4 flex items-center justify-between">
+        <span className="text-red-500 font-bold text-xl tracking-widest uppercase">
+          ESCAPESNAP
+        </span>
+      </header>
+
+      <main className="flex-1 flex items-center justify-center px-8 py-12">
+        <div className="w-full max-w-2xl text-center">
+          <p className="text-xs text-red-500 tracking-widest mb-3">
+            INITIATE PROTOCOL
+          </p>
+          <h1 className="text-6xl font-bold tracking-widest uppercase text-gray-100 mb-6">
+            ESCAPESNAP
+          </h1>
+          <p className="text-sm text-gray-400 tracking-wide mb-12 max-w-md mx-auto leading-relaxed">
+            Turn your surroundings into an interactive escape room. Solve visual riddles, collect clues, and crack the final code — wherever you are.
+          </p>
+
+          <button
+            onClick={() => navigate('/game/create')}
+            className="bg-red-700 hover:bg-red-600 text-white text-sm tracking-widest uppercase px-12 py-4 transition-colors cursor-pointer"
+          >
+            CREATE NEW GAME
+          </button>
+
+          <p className="text-xs text-gray-600 tracking-widest mt-8">
+            HOST A SESSION · BEGIN MISSION
+          </p>
+        </div>
+      </main>
+
+      <footer className="border-t border-gray-800 px-8 py-4 text-center">
+        <p className="text-xs text-gray-600 tracking-widest">
+          ESCAPESNAP
+        </p>
+      </footer>
+    </div>
+  );
+};
+
+export default Landing;

--- a/imports/ui/host/pages/lobby/Lobby.jsx
+++ b/imports/ui/host/pages/lobby/Lobby.jsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
-import { useParams } from 'react-router';
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router';
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
 import { Games } from '../../../../api/games/GamesCollection';
 
 const Lobby = () => {
   const { gameId } = useParams();
+  const navigate = useNavigate();
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState(null);
 
@@ -16,6 +17,12 @@ const Lobby = () => {
       game: Games.findOne(gameId),
     };
   }, [gameId]);
+
+  useEffect(() => {
+    if (game?.status === 'in_progress') {
+      navigate(`/game/${gameId}/progress`);
+    }
+  }, [game?.status]);
 
   const handleStartGame = async () => {
     setStarting(true);

--- a/imports/ui/host/pages/lobby/Lobby.jsx
+++ b/imports/ui/host/pages/lobby/Lobby.jsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import { useParams } from 'react-router';
+import { Meteor } from 'meteor/meteor';
+import { useTracker } from 'meteor/react-meteor-data';
+import { Games } from '../../../../api/games/GamesCollection';
+
+const Lobby = () => {
+  const { gameId } = useParams();
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const { game, loading } = useTracker(() => {
+    const sub = Meteor.subscribe('games.current', gameId);
+    return {
+      loading: !sub.ready(),
+      game: Games.findOne(gameId),
+    };
+  }, [gameId]);
+
+  const handleStartGame = async () => {
+    setStarting(true);
+    setError(null);
+    try {
+      await Meteor.callAsync('games.start', gameId);
+    } catch (err) {
+      setError(err.reason || err.message || 'FAILED TO START GAME');
+      setStarting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-950 text-gray-100 flex items-center justify-center">
+        <p className="text-xs tracking-widest text-gray-500">LOADING...</p>
+      </div>
+    );
+  }
+
+  if (!game) {
+    return (
+      <div className="min-h-screen bg-gray-950 text-gray-100 flex items-center justify-center">
+        <p className="text-xs tracking-widest text-red-500">GAME NOT FOUND</p>
+      </div>
+    );
+  }
+
+  const gameStarted = game.status === 'in_progress';
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100 flex flex-col">
+      <header className="border-b border-gray-800 px-8 py-4 flex items-center justify-between">
+        <span className="text-red-500 font-bold text-xl tracking-widest uppercase">
+          ESCAPESNAP
+        </span>
+        <span className="text-xs text-gray-500 tracking-widest uppercase">
+          GAME LOBBY
+        </span>
+      </header>
+
+      <main className="flex-1 flex items-center justify-center px-8 py-12">
+        <div className="w-full max-w-lg space-y-6">
+          <div className="mb-8">
+            <p className="text-xs text-red-500 tracking-widest mb-1">
+              MISSION BRIEFING
+            </p>
+            <h1 className="text-3xl font-bold tracking-widest uppercase text-gray-100">
+              AWAITING AGENTS
+            </h1>
+            <p className="text-xs text-gray-500 mt-2 tracking-wide">
+              SHARE THE GAME CODE WITH YOUR TEAM
+            </p>
+          </div>
+
+          <div className="border border-gray-800 p-6 text-center">
+            <p className="text-xs text-gray-500 tracking-widest mb-2">
+              GAME CODE
+            </p>
+            <p className="text-2xl font-mono font-bold text-red-400 tracking-widest break-all">
+              {gameId}
+            </p>
+          </div>
+
+          {error && (
+            <p className="text-xs text-red-500 tracking-widest">!! {error}</p>
+          )}
+
+          {gameStarted ? (
+            <div className="border border-red-800 bg-red-950 p-4 text-center">
+              <p className="text-sm text-red-400 tracking-widest uppercase">
+                MISSION ACTIVE — AGENTS DEPLOYED
+              </p>
+            </div>
+          ) : (
+            <button
+              onClick={handleStartGame}
+              disabled={starting}
+              className="w-full bg-red-700 hover:bg-red-600 disabled:bg-gray-800 disabled:text-gray-600 text-white text-sm tracking-widest uppercase py-4 transition-colors cursor-pointer disabled:cursor-not-allowed"
+            >
+              {starting ? 'DEPLOYING AGENTS...' : 'START MISSION'}
+            </button>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default Lobby;

--- a/imports/ui/host/pages/progress/ProgressPage.jsx
+++ b/imports/ui/host/pages/progress/ProgressPage.jsx
@@ -77,9 +77,8 @@ const Sidebar = ({ gameId, expanded, onToggle }) => {
   const navigate = useNavigate();
 
   const navItems = [
-    { label: 'DASHBOARD', Icon: DashboardIcon, route: '/', active: false },
     { label: 'OPERATIVES', Icon: OperativesIcon, route: `/game/${gameId}/progress`, active: true },
-    { label: 'LOGS', Icon: LogsIcon, route: null, active: false },
+    { label: 'FINAL RIDDLE', Icon: RiddleIcon, route: `/game/${gameId}/final-riddle`, active: false },
   ];
 
   return (

--- a/imports/ui/host/pages/progress/ProgressPage.jsx
+++ b/imports/ui/host/pages/progress/ProgressPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
@@ -65,9 +65,11 @@ const RiddleIcon = ({ color }) => (
   </svg>
 );
 
-const ChevronIcon = ({ expanded }) => (
-  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style={{ transition: 'transform 0.25s', transform: expanded ? 'rotate(0deg)' : 'rotate(180deg)', flexShrink: 0 }}>
-    <path d="M10 5L7 8L4 5" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+const HamburgerIcon = () => (
+  <svg width="18" height="14" viewBox="0 0 18 14" fill="none" style={{ flexShrink: 0 }}>
+    <line x1="0" y1="1" x2="18" y2="1" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="0" y1="7" x2="18" y2="7" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="0" y1="13" x2="18" y2="13" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
   </svg>
 );
 
@@ -94,16 +96,21 @@ const Sidebar = ({ gameId, expanded, onToggle }) => {
         flexShrink: 0,
       }}
     >
-      {/* Logo area */}
-      <div style={{ padding: expanded ? '32px 24px 16px' : '32px 0 16px', display: 'flex', flexDirection: 'column', alignItems: expanded ? 'flex-start' : 'center', transition: 'padding 0.25s' }}>
-        {expanded ? (
-          <>
+      {/* Toggle button + Logo area */}
+      <div style={{ borderBottom: '1px solid #1c1b1b', display: 'flex', alignItems: 'center', justifyContent: expanded ? 'space-between' : 'center', padding: expanded ? '20px 16px 20px 24px' : '20px 0' }}>
+        {expanded && (
+          <div>
             <div style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1', whiteSpace: 'nowrap' }}>GAME</div>
             <div style={{ fontWeight: 500, fontSize: 10, letterSpacing: '0.5px', color: '#8b0000', marginTop: 2, whiteSpace: 'nowrap' }}>LOBBY</div>
-          </>
-        ) : (
-          <div style={{ fontWeight: 700, fontSize: 11, letterSpacing: '1px', color: '#8b0000' }}>G</div>
+          </div>
         )}
+        <button
+          onClick={onToggle}
+          title={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
+          style={{ background: 'transparent', cursor: 'pointer', opacity: 0.5, padding: 4, display: 'flex', alignItems: 'center' }}
+        >
+          <HamburgerIcon />
+        </button>
       </div>
 
       {/* Nav items */}
@@ -138,24 +145,6 @@ const Sidebar = ({ gameId, expanded, onToggle }) => {
         ))}
       </nav>
 
-      {/* Toggle button */}
-      <button
-        onClick={onToggle}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: expanded ? 'flex-end' : 'center',
-          padding: expanded ? '12px 16px' : '12px 0',
-          background: 'transparent',
-          cursor: 'pointer',
-          borderTop: '1px solid #1c1b1b',
-          opacity: 0.5,
-          width: '100%',
-        }}
-        title={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
-      >
-        <ChevronIcon expanded={expanded} />
-      </button>
     </aside>
   );
 };
@@ -163,6 +152,7 @@ const Sidebar = ({ gameId, expanded, onToggle }) => {
 const ProgressPage = () => {
   const { gameId } = useParams();
   const [sidebarExpanded, setSidebarExpanded] = useState(true);
+  const [timeLeft, setTimeLeft] = useState(null);
 
   const { game, loading } = useTracker(() => {
     const sub = Meteor.subscribe('games.current', gameId);
@@ -171,6 +161,21 @@ const ProgressPage = () => {
       game: Games.findOne(gameId),
     };
   }, [gameId]);
+
+  useEffect(() => {
+    if (!game?.startedAt || !game?.timerMinutes) {
+      setTimeLeft(null);
+      return;
+    }
+    const tick = () => {
+      const elapsed = Date.now() - new Date(game.startedAt).getTime();
+      const remaining = Math.max(0, game.timerMinutes * 60 * 1000 - elapsed);
+      setTimeLeft(remaining);
+    };
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, [game?.startedAt, game?.timerMinutes]);
 
   if (loading) {
     return (
@@ -191,6 +196,16 @@ const ProgressPage = () => {
   const players = game.players || [];
   const pinRaw = gameId.slice(-6).toUpperCase();
   const pin = pinRaw.slice(0, 3) + '-' + pinRaw.slice(3);
+
+  const formatTime = (ms) => {
+    if (ms === null) return '--:--';
+    const total = Math.floor(ms / 1000);
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  };
+
+  const isExpired = timeLeft === 0;
 
   return (
     <main className="flex min-h-screen" style={{ background: '#131313', color: '#e5e2e1', fontFamily: "'Space Grotesk', Helvetica, sans-serif" }}>
@@ -233,9 +248,14 @@ const ProgressPage = () => {
 
           {/* Stats row */}
           <div className="grid grid-cols-4" style={{ height: 160 }}>
-            <div className="flex flex-col justify-between p-6" style={{ background: '#0e0e0e', borderLeft: '2px solid #8b0000' }}>
+            <div className="flex flex-col justify-between p-6" style={{ background: '#0e0e0e', borderLeft: `2px solid ${isExpired ? '#ff0000' : '#8b0000'}` }}>
               <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>TIME REMAINING</span>
-              <span style={{ fontWeight: 300, fontSize: 60, letterSpacing: '-3px', lineHeight: '60px', color: '#e5e2e1' }}>42:18</span>
+              <span style={{ fontWeight: 300, fontSize: 60, letterSpacing: '-3px', lineHeight: '60px', color: isExpired ? '#ff4444' : '#e5e2e1' }}>
+                {game.startedAt ? formatTime(timeLeft) : '--:--'}
+              </span>
+              {!game.startedAt && (
+                <span style={{ fontSize: 9, color: '#aa8984', opacity: 0.6, letterSpacing: '0.5px' }}>GAME NOT STARTED</span>
+              )}
             </div>
 
             <div className="flex flex-col justify-between p-6" style={{ background: '#1c1b1b' }}>

--- a/imports/ui/host/pages/progress/ProgressPage.jsx
+++ b/imports/ui/host/pages/progress/ProgressPage.jsx
@@ -151,6 +151,7 @@ const Sidebar = ({ gameId, expanded, onToggle }) => {
 
 const ProgressPage = () => {
   const { gameId } = useParams();
+  const navigate = useNavigate();
   const [sidebarExpanded, setSidebarExpanded] = useState(true);
   const [timeLeft, setTimeLeft] = useState(null);
 

--- a/imports/ui/host/pages/progress/ProgressPage.jsx
+++ b/imports/ui/host/pages/progress/ProgressPage.jsx
@@ -222,26 +222,6 @@ const ProgressPage = () => {
             <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1' }}>ESCAPESNAP</span>
             <div style={{ width: 1, height: 16, background: '#5a403c', opacity: 0.3 }} />
           </div>
-          <div className="flex items-center gap-3">
-            <div className="flex items-center gap-2 px-3 py-1" style={{ background: '#0e0e0e', border: '1px solid rgba(90,64,60,0.1)' }}>
-              <span style={{ fontSize: 10, color: '#aa8984' }}>PIN:</span>
-              <span style={{ fontWeight: 700, fontSize: 14, letterSpacing: '1.4px', color: '#e5e2e1' }}>{pin}</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <circle cx="9" cy="9" r="7" stroke="#aa8984" strokeWidth="1.5" />
-                <polyline points="9,5 9,9 12,11" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <circle cx="9" cy="6" r="3" stroke="#aa8984" strokeWidth="1.5" />
-                <path d="M3 16c0-3.314 2.686-6 6-6s6 2.686 6 6" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
-              </svg>
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <path d="M9 2C6.24 2 4 4.24 4 7v5l-1.5 1.5V15h13v-1.5L14 12V7c0-2.76-2.24-5-5-5z" stroke="#aa8984" strokeWidth="1.5" strokeLinejoin="round" />
-                <path d="M7 15a2 2 0 004 0" stroke="#aa8984" strokeWidth="1.5" />
-              </svg>
-            </div>
-          </div>
         </header>
 
         {/* Body */}

--- a/imports/ui/host/pages/progress/ProgressPage.jsx
+++ b/imports/ui/host/pages/progress/ProgressPage.jsx
@@ -1,0 +1,342 @@
+import React, { useState } from 'react';
+import { useParams, useNavigate } from 'react-router';
+import { Meteor } from 'meteor/meteor';
+import { useTracker } from 'meteor/react-meteor-data';
+import { Games } from '../../../../api/games/GamesCollection';
+
+const MOCK_PUZZLE_DATA = [
+  { puzzles: [true, true, true, false, false], status: 'COMPLETED' },
+  { puzzles: [true, false, false, false, false], status: 'NEEDS HELP' },
+  { puzzles: [true, true, true, false, false], status: 'COMPLETED' },
+  { puzzles: [true, true, false, false, false], status: 'NEEDS HELP' },
+];
+
+const MOCK_EVENTS = [
+  { time: '14:22:10', message: 'DYLAN HAS COMPLETED THE PUZZLE', highlight: true },
+  { time: '14:18:05', message: 'SEBASTIAN HAS UPLOADED AN INCORRECT ANSWER', highlight: false },
+  { time: '14:15:33', message: 'KAYVIS HAS UPLOADED AN INCORRECT ANSWER', highlight: false },
+  { time: '14:10:12', message: 'CASIE HAS COMPLETED THE PUZZLE', highlight: false },
+];
+
+const CheckIcon = () => (
+  <svg width="16" height="12" viewBox="0 0 16 12" fill="none">
+    <path d="M1 6L6 11L15 1" stroke="#4ade80" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const CrossIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+    <path d="M1 1L13 13M13 1L1 13" stroke="#ef4444" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+const DashboardIcon = ({ color }) => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ flexShrink: 0 }}>
+    <rect x="1" y="1" width="6" height="6" rx="1" stroke={color} strokeWidth="1.5" />
+    <rect x="11" y="1" width="6" height="6" rx="1" stroke={color} strokeWidth="1.5" />
+    <rect x="1" y="11" width="6" height="6" rx="1" stroke={color} strokeWidth="1.5" />
+    <rect x="11" y="11" width="6" height="6" rx="1" stroke={color} strokeWidth="1.5" />
+  </svg>
+);
+
+const OperativesIcon = ({ color }) => (
+  <svg width="19" height="20" viewBox="0 0 19 20" fill="none" style={{ flexShrink: 0 }}>
+    <circle cx="9.5" cy="10" r="8" stroke={color} strokeWidth="1.5" />
+    <circle cx="9.5" cy="10" r="3" stroke={color} strokeWidth="1.5" />
+    <line x1="9.5" y1="1" x2="9.5" y2="4" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="9.5" y1="16" x2="9.5" y2="19" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="1" y1="10" x2="4" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="15" y1="10" x2="18" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const LogsIcon = ({ color }) => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ flexShrink: 0 }}>
+    <rect x="1" y="1" width="16" height="16" rx="2" stroke={color} strokeWidth="1.5" />
+    <line x1="4" y1="6" x2="14" y2="6" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="4" y1="9" x2="14" y2="9" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="4" y1="12" x2="10" y2="12" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const RiddleIcon = ({ color }) => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ flexShrink: 0 }}>
+    <path d="M9 1L11.5 6.5L17 7.3L13 11.2L14 17L9 14.3L4 17L5 11.2L1 7.3L6.5 6.5L9 1Z" stroke={color} strokeWidth="1.5" strokeLinejoin="round" />
+  </svg>
+);
+
+const ChevronIcon = ({ expanded }) => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style={{ transition: 'transform 0.25s', transform: expanded ? 'rotate(0deg)' : 'rotate(180deg)', flexShrink: 0 }}>
+    <path d="M10 5L7 8L4 5" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const Sidebar = ({ gameId, expanded, onToggle }) => {
+  const navigate = useNavigate();
+
+  const navItems = [
+    { label: 'DASHBOARD', Icon: DashboardIcon, route: '/', active: false },
+    { label: 'OPERATIVES', Icon: OperativesIcon, route: `/game/${gameId}/progress`, active: true },
+    { label: 'LOGS', Icon: LogsIcon, route: null, active: false },
+  ];
+
+  return (
+    <aside
+      style={{
+        width: expanded ? 200 : 60,
+        minHeight: '100vh',
+        background: '#0e0e0e',
+        borderRight: '1px solid #1c1b1b',
+        display: 'flex',
+        flexDirection: 'column',
+        transition: 'width 0.25s ease',
+        overflow: 'hidden',
+        flexShrink: 0,
+      }}
+    >
+      {/* Logo area */}
+      <div style={{ padding: expanded ? '32px 24px 16px' : '32px 0 16px', display: 'flex', flexDirection: 'column', alignItems: expanded ? 'flex-start' : 'center', transition: 'padding 0.25s' }}>
+        {expanded ? (
+          <>
+            <div style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1', whiteSpace: 'nowrap' }}>GAME</div>
+            <div style={{ fontWeight: 500, fontSize: 10, letterSpacing: '0.5px', color: '#8b0000', marginTop: 2, whiteSpace: 'nowrap' }}>LOBBY</div>
+          </>
+        ) : (
+          <div style={{ fontWeight: 700, fontSize: 11, letterSpacing: '1px', color: '#8b0000' }}>G</div>
+        )}
+      </div>
+
+      {/* Nav items */}
+      <nav style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        {navItems.map(({ label, Icon, route, active }) => (
+          <button
+            key={label}
+            onClick={() => route && navigate(route)}
+            title={!expanded ? label : undefined}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: expanded ? 16 : 0,
+              justifyContent: expanded ? 'flex-start' : 'center',
+              padding: expanded ? '16px 24px' : '16px 0',
+              background: active ? '#1c1b1b' : 'transparent',
+              borderLeft: active ? '2px solid #8b0000' : '2px solid transparent',
+              cursor: route ? 'pointer' : 'default',
+              opacity: active ? 1 : 0.7,
+              width: '100%',
+              textAlign: 'left',
+              transition: 'background 0.15s',
+            }}
+          >
+            <Icon color={active ? '#e5e2e1' : '#aa8984'} />
+            {expanded && (
+              <span style={{ fontSize: 16, fontWeight: 500, letterSpacing: '0.8px', color: active ? '#e5e2e1' : '#aa8984', whiteSpace: 'nowrap' }}>
+                {label}
+              </span>
+            )}
+          </button>
+        ))}
+      </nav>
+
+      {/* Toggle button */}
+      <button
+        onClick={onToggle}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: expanded ? 'flex-end' : 'center',
+          padding: expanded ? '12px 16px' : '12px 0',
+          background: 'transparent',
+          cursor: 'pointer',
+          borderTop: '1px solid #1c1b1b',
+          opacity: 0.5,
+          width: '100%',
+        }}
+        title={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
+      >
+        <ChevronIcon expanded={expanded} />
+      </button>
+    </aside>
+  );
+};
+
+const ProgressPage = () => {
+  const { gameId } = useParams();
+  const [sidebarExpanded, setSidebarExpanded] = useState(true);
+
+  const { game, loading } = useTracker(() => {
+    const sub = Meteor.subscribe('games.current', gameId);
+    return {
+      loading: !sub.ready(),
+      game: Games.findOne(gameId),
+    };
+  }, [gameId]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: '#131313' }}>
+        <p style={{ color: '#aa8984', fontSize: 10, letterSpacing: '1px' }}>LOADING...</p>
+      </div>
+    );
+  }
+
+  if (!game) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: '#131313' }}>
+        <p style={{ color: '#8b0000', fontSize: 10, letterSpacing: '1px' }}>GAME NOT FOUND</p>
+      </div>
+    );
+  }
+
+  const players = game.players || [];
+  const pinRaw = gameId.slice(-6).toUpperCase();
+  const pin = pinRaw.slice(0, 3) + '-' + pinRaw.slice(3);
+
+  return (
+    <main className="flex min-h-screen" style={{ background: '#131313', color: '#e5e2e1', fontFamily: "'Space Grotesk', Helvetica, sans-serif" }}>
+
+      <Sidebar gameId={gameId} expanded={sidebarExpanded} onToggle={() => setSidebarExpanded(v => !v)} />
+
+      {/* Main content */}
+      <section className="flex flex-col flex-1" style={{ minWidth: 0 }}>
+
+        {/* Header */}
+        <header className="flex items-center justify-between px-6 py-4" style={{ background: '#131313', borderBottom: '2px solid #1c1b1b' }}>
+          <div className="flex items-center gap-4">
+            <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1' }}>ESCAPESNAP</span>
+            <div style={{ width: 1, height: 16, background: '#5a403c', opacity: 0.3 }} />
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2 px-3 py-1" style={{ background: '#0e0e0e', border: '1px solid rgba(90,64,60,0.1)' }}>
+              <span style={{ fontSize: 10, color: '#aa8984' }}>PIN:</span>
+              <span style={{ fontWeight: 700, fontSize: 14, letterSpacing: '1.4px', color: '#e5e2e1' }}>{pin}</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <circle cx="9" cy="9" r="7" stroke="#aa8984" strokeWidth="1.5" />
+                <polyline points="9,5 9,9 12,11" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <circle cx="9" cy="6" r="3" stroke="#aa8984" strokeWidth="1.5" />
+                <path d="M3 16c0-3.314 2.686-6 6-6s6 2.686 6 6" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <path d="M9 2C6.24 2 4 4.24 4 7v5l-1.5 1.5V15h13v-1.5L14 12V7c0-2.76-2.24-5-5-5z" stroke="#aa8984" strokeWidth="1.5" strokeLinejoin="round" />
+                <path d="M7 15a2 2 0 004 0" stroke="#aa8984" strokeWidth="1.5" />
+              </svg>
+            </div>
+          </div>
+        </header>
+
+        {/* Body */}
+        <div className="flex-1 p-8 flex flex-col gap-8">
+
+          {/* Stats row */}
+          <div className="grid grid-cols-4" style={{ height: 160 }}>
+            <div className="flex flex-col justify-between p-6" style={{ background: '#0e0e0e', borderLeft: '2px solid #8b0000' }}>
+              <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>TIME REMAINING</span>
+              <span style={{ fontWeight: 300, fontSize: 60, letterSpacing: '-3px', lineHeight: '60px', color: '#e5e2e1' }}>42:18</span>
+            </div>
+
+            <div className="flex flex-col justify-between p-6" style={{ background: '#1c1b1b' }}>
+              <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>TEAM PROGRESS</span>
+              <div className="flex items-end gap-2">
+                <span style={{ fontWeight: 700, fontSize: 48, lineHeight: '48px', color: '#e5e2e1' }}>64</span>
+                <span style={{ fontSize: 24, color: '#aa8984', paddingBottom: 4 }}>%</span>
+              </div>
+              <div style={{ height: 4, background: '#353534' }}>
+                <div style={{ height: '100%', width: '64%', background: '#8b0000' }} />
+              </div>
+            </div>
+
+            <div className="flex flex-col justify-between p-6" style={{ background: '#1c1b1b' }}>
+              <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>CURRENT ROUND</span>
+              <div className="flex items-end gap-2">
+                <span style={{ fontWeight: 700, fontSize: 48, lineHeight: '48px', color: '#e5e2e1' }}>03</span>
+                <span style={{ fontSize: 18, color: '#aa8984', paddingBottom: 6 }}>/ 05</span>
+              </div>
+              <span style={{ fontSize: 10, color: '#aa8984', opacity: 0.6 }}>REMAINING PUZZLES: 2</span>
+            </div>
+
+            <div className="flex items-center justify-center p-6 relative" style={{ background: '#0e0e0e' }}>
+              <span style={{ position: 'absolute', top: 8, right: 8, fontSize: 8, color: '#aa8984', opacity: 0.4 }}>AUTH_QR_SCAN</span>
+              <div style={{ width: 96, height: 96, background: 'rgba(255,255,255,0.8)' }} />
+            </div>
+          </div>
+
+          {/* Operative Manifest */}
+          <div style={{ background: '#1c1b1b' }}>
+            <div className="flex items-center justify-between px-6 py-4" style={{ borderBottom: '1px solid #353534' }}>
+              <div className="flex items-center gap-3">
+                <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+                <span style={{ fontWeight: 700, fontSize: 14, letterSpacing: '1.4px', color: '#e5e2e1' }}>OPERATIVE_MANIFEST</span>
+              </div>
+              <div className="flex items-center gap-4">
+                <div className="flex items-center gap-1">
+                  <CheckIcon />
+                  <span style={{ fontSize: 10, color: '#aa8984' }}>SOLVED</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <CrossIcon />
+                  <span style={{ fontSize: 10, color: '#aa8984' }}>IN PROGRESS</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center px-6 py-3" style={{ background: '#0e0e0e', borderBottom: '1px solid #353534' }}>
+              <div style={{ width: 160, fontSize: 10, fontWeight: 700, letterSpacing: '1px', color: '#aa8984' }}>PLAYER</div>
+              {[1, 2, 3, 4, 5].map(n => (
+                <div key={n} style={{ flex: 1, fontSize: 10, fontWeight: 700, letterSpacing: '1px', color: '#aa8984', textAlign: 'center' }}>PUZZLE {n}</div>
+              ))}
+              <div style={{ width: 120, fontSize: 10, fontWeight: 700, letterSpacing: '1px', color: '#aa8984', textAlign: 'right' }}>STATUS</div>
+            </div>
+
+            {players.map((player, i) => {
+              const data = MOCK_PUZZLE_DATA[i] || { puzzles: [false, false, false, false, false], status: 'NEEDS HELP' };
+              const isCompleted = data.status === 'COMPLETED';
+              return (
+                <div key={player.id} className="flex items-center px-6 py-4" style={{ borderTop: i > 0 ? '1px solid #353534' : 'none' }}>
+                  <div style={{ width: 160, fontWeight: 700, fontSize: 12, color: '#e5e2e1' }}>{player.name.toUpperCase()}</div>
+                  {data.puzzles.map((solved, pi) => (
+                    <div key={pi} style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                      {solved ? <CheckIcon /> : pi < 3 ? <CrossIcon /> : null}
+                    </div>
+                  ))}
+                  <div style={{ width: 120, display: 'flex', justifyContent: 'flex-end' }}>
+                    <span style={{
+                      fontSize: 9,
+                      padding: '2px 8px',
+                      background: isCompleted ? '#474747' : '#93000a',
+                      color: isCompleted ? '#e5e2e1' : '#ffdad6',
+                    }}>
+                      {data.status}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Event Log */}
+          <div className="p-6" style={{ background: '#0e0e0e', borderLeft: '1px solid rgba(90,64,60,0.2)' }}>
+            <div className="flex items-center gap-3 mb-4">
+              <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+              <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>EVENT_LOG</span>
+            </div>
+            <div className="flex flex-col gap-4">
+              {MOCK_EVENTS.map((event, i) => (
+                <div key={i} className="flex items-start gap-4 pl-3 py-1" style={{ borderLeft: `1px solid ${event.highlight ? '#8b0000' : 'rgba(90,64,60,0.3)'}` }}>
+                  <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 11, color: '#aa8984', whiteSpace: 'nowrap' }}>[ {event.time} ]</span>
+                  <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 11, color: event.highlight ? '#e5e2e1' : '#e3beb8' }}>{event.message}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default ProgressPage;

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useParams } from 'react-router';
 import { useFinalRiddle } from '/imports/ui/shared/hooks/useFinalRiddle.js';
 import { useRevealedLetters } from '/imports/ui/shared/hooks/useRevealedLetters.js';
@@ -6,11 +6,13 @@ import GameNotFound from '/imports/ui/shared/components/GameNotFound.jsx';
 import RevealedLetters from '/imports/ui/host/components/riddle/RevealedLetters.jsx';
 import FinalRiddle from '/imports/ui/host/components/riddle/FinalRiddle.jsx';
 import FinalRiddleInput from '/imports/ui/host/components/riddle/FinalRiddleInput.jsx';
+import WinScreen from '/imports/ui/host/pages/game-completion/WinScreen.jsx';
 
 const FinalRiddlePage = () => {
   const { gameId } = useParams();
   const { loading, finalRiddle, gameStatus } = useFinalRiddle(gameId);
   const { lettersLoading, letters } = useRevealedLetters(gameId);
+  const [hasWon, setHasWon] = useState(false);
 
   if (loading || lettersLoading) return <div className='min-h-screen flex items-center justify-center'>
                             <span className="loading loading-spinner text-red-500"></span>
@@ -19,12 +21,14 @@ const FinalRiddlePage = () => {
   if (gameStatus !== 'final_riddle')
     return <p className="text-red-500">Not in final riddle phase.</p>;
 
+  if (hasWon) return <WinScreen onPlayAgain={() => setHasWon(false)} />;
+
   return (
     <div className='min-h-screen'>
       THIS IS THE FINAL RIDDLE PAGE
       <FinalRiddle finalRiddle={finalRiddle} />
       <RevealedLetters letters={letters} />
-      <FinalRiddleInput gameId={gameId}/>
+      <FinalRiddleInput gameId={gameId} onCorrect={() => setHasWon(true)} />
     </div>
   );
 };

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -2,19 +2,23 @@ import React from 'react';
 import { useParams } from 'react-router';
 import { useFinalRiddle } from '/imports/ui/shared/hooks/useFinalRiddle.js';
 import GameNotFound from '/imports/ui/shared/components/GameNotFound.jsx';
+import FinalRiddle from '/imports/ui/host/components/riddle/FinalRiddle.jsx';
 
 const FinalRiddlePage = () => {
   const { gameId } = useParams();
   const { loading, finalRiddle, gameStatus } = useFinalRiddle(gameId);
 
-  if (loading) return <p className="text-white">Loading...</p>;
+  if (loading) return <div className='min-h-screen flex items-center justify-center'>
+                            <span className="loading loading-spinner text-red-500"></span>
+                        </div>;
   if (!finalRiddle) return <GameNotFound />;
   if (gameStatus !== 'final_riddle')
     return <p className="text-red-500">Not in final riddle phase.</p>;
 
   return (
-    <div>
+    <div className='min-h-screen'>
       THIS IS THE FINAL RIDDLE PAGE
+      <FinalRiddle finalRiddle={finalRiddle} />
     </div>
   );
 };

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { useParams } from 'react-router';
 import { useFinalRiddle } from '/imports/ui/shared/hooks/useFinalRiddle.js';
+import { useRevealedLetters } from '/imports/ui/shared/hooks/useRevealedLetters.js';
 import GameNotFound from '/imports/ui/shared/components/GameNotFound.jsx';
 
 const FinalRiddlePage = () => {
   const { gameId } = useParams();
   const { loading, finalRiddle, gameStatus } = useFinalRiddle(gameId);
+  const { lettersLoading, letters } = useRevealedLetters(gameId);
 
-  if (loading) return <p className="text-white">Loading...</p>;
+  if (loading || lettersLoading) return <div className='min-h-screen flex items-center justify-center'>
+                            <span className="loading loading-spinner text-red-500"></span>
+                        </div>;
   if (!finalRiddle) return <GameNotFound />;
   if (gameStatus !== 'final_riddle')
     return <p className="text-red-500">Not in final riddle phase.</p>;
@@ -15,6 +19,8 @@ const FinalRiddlePage = () => {
   return (
     <div>
       THIS IS THE FINAL RIDDLE PAGE
+      <p></p>
+      {letters}
     </div>
   );
 };

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -22,8 +22,8 @@ const FinalRiddlePage = () => {
   return (
     <div className='min-h-screen'>
       THIS IS THE FINAL RIDDLE PAGE
-      <RevealedLetters letters={letters} />
       <FinalRiddle finalRiddle={finalRiddle} />
+      <RevealedLetters letters={letters} />
       <FinalRiddleInput gameId={gameId}/>
     </div>
   );

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router';
 import { useFinalRiddle } from '/imports/ui/shared/hooks/useFinalRiddle.js';
 import { useRevealedLetters } from '/imports/ui/shared/hooks/useRevealedLetters.js';
+import { useNavigate } from 'react-router';
+
 import GameNotFound from '/imports/ui/shared/components/GameNotFound.jsx';
 import RevealedLetters from '/imports/ui/host/components/riddle/RevealedLetters.jsx';
 import FinalRiddle from '/imports/ui/host/components/riddle/FinalRiddle.jsx';
@@ -14,6 +16,8 @@ const FinalRiddlePage = () => {
   const { lettersLoading, letters } = useRevealedLetters(gameId);
   const [hasWon, setHasWon] = useState(false);
 
+  const navigate = useNavigate();
+
   if (loading || lettersLoading) return <div className='min-h-screen flex items-center justify-center'>
                             <span className="loading loading-spinner text-red-500"></span>
                         </div>;
@@ -21,7 +25,7 @@ const FinalRiddlePage = () => {
   if (gameStatus !== 'final_riddle')
     return <p className="text-red-500">Not in final riddle phase.</p>;
 
-  if (hasWon) return <WinScreen onPlayAgain={() => setHasWon(false)} />;
+  if (hasWon) return <WinScreen onPlayAgain={() => navigate('/game/create')} />;
 
   return (
       <div className='min-h-screen bg-gray-900'>

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const FinalRiddlePage = () => {
+  return (
+    <div>
+      THIS IS THE FINAL RIDDLE PAGE
+    </div>
+  )
+}
+
+export default FinalRiddlePage

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -1,39 +1,188 @@
 import React, { useState } from 'react';
-import { useParams } from 'react-router';
+import { useParams, useNavigate } from 'react-router';
 import { useFinalRiddle } from '/imports/ui/shared/hooks/useFinalRiddle.js';
 import { useRevealedLetters } from '/imports/ui/shared/hooks/useRevealedLetters.js';
-import { useNavigate } from 'react-router';
-
 import GameNotFound from '/imports/ui/shared/components/GameNotFound.jsx';
-import RevealedLetters from '/imports/ui/host/components/riddle/RevealedLetters.jsx';
-import FinalRiddle from '/imports/ui/host/components/riddle/FinalRiddle.jsx';
-import FinalRiddleInput from '/imports/ui/host/components/riddle/FinalRiddleInput.jsx';
 import WinScreen from '/imports/ui/host/pages/game-completion/WinScreen.jsx';
+import FinalRiddleInput from '/imports/ui/host/components/riddle/FinalRiddleInput.jsx';
+
+const HamburgerIcon = () => (
+  <svg width="18" height="14" viewBox="0 0 18 14" fill="none" style={{ flexShrink: 0 }}>
+    <line x1="0" y1="1" x2="18" y2="1" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="0" y1="7" x2="18" y2="7" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="0" y1="13" x2="18" y2="13" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const OperativesIcon = ({ color }) => (
+  <svg width="19" height="20" viewBox="0 0 19 20" fill="none" style={{ flexShrink: 0 }}>
+    <circle cx="9.5" cy="10" r="8" stroke={color} strokeWidth="1.5" />
+    <circle cx="9.5" cy="10" r="3" stroke={color} strokeWidth="1.5" />
+    <line x1="9.5" y1="1" x2="9.5" y2="4" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="9.5" y1="16" x2="9.5" y2="19" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="1" y1="10" x2="4" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="15" y1="10" x2="18" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const RiddleIcon = ({ color }) => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ flexShrink: 0 }}>
+    <path d="M9 1L11.5 6.5L17 7.3L13 11.2L14 17L9 14.3L4 17L5 11.2L1 7.3L6.5 6.5L9 1Z" stroke={color} strokeWidth="1.5" strokeLinejoin="round" />
+  </svg>
+);
+
+const Sidebar = ({ gameId, expanded, onToggle }) => {
+  const navigate = useNavigate();
+
+  const navItems = [
+    { label: 'OPERATIVES', Icon: OperativesIcon, route: `/game/${gameId}/progress`, active: false },
+    { label: 'FINAL RIDDLE', Icon: RiddleIcon, route: `/game/${gameId}/final-riddle`, active: true },
+  ];
+
+  return (
+    <aside style={{
+      width: expanded ? 200 : 60,
+      minHeight: '100vh',
+      background: '#0e0e0e',
+      borderRight: '1px solid #1c1b1b',
+      display: 'flex',
+      flexDirection: 'column',
+      transition: 'width 0.25s ease',
+      overflow: 'hidden',
+      flexShrink: 0,
+    }}>
+      <div style={{ borderBottom: '1px solid #1c1b1b', display: 'flex', alignItems: 'center', justifyContent: expanded ? 'space-between' : 'center', padding: expanded ? '20px 16px 20px 24px' : '20px 0' }}>
+        {expanded && (
+          <div>
+            <div style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1', whiteSpace: 'nowrap' }}>GAME</div>
+            <div style={{ fontWeight: 500, fontSize: 10, letterSpacing: '0.5px', color: '#8b0000', marginTop: 2, whiteSpace: 'nowrap' }}>FINAL RIDDLE</div>
+          </div>
+        )}
+        <button onClick={onToggle} title={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
+          style={{ background: 'transparent', cursor: 'pointer', opacity: 0.5, padding: 4, display: 'flex', alignItems: 'center' }}>
+          <HamburgerIcon />
+        </button>
+      </div>
+
+      <nav style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        {navItems.map(({ label, Icon, route, active }) => (
+          <button key={label} onClick={() => route && navigate(route)} title={!expanded ? label : undefined}
+            style={{
+              display: 'flex', alignItems: 'center',
+              gap: expanded ? 16 : 0,
+              justifyContent: expanded ? 'flex-start' : 'center',
+              padding: expanded ? '16px 24px' : '16px 0',
+              background: active ? '#1c1b1b' : 'transparent',
+              borderLeft: active ? '2px solid #8b0000' : '2px solid transparent',
+              cursor: 'pointer', opacity: active ? 1 : 0.7,
+              width: '100%', textAlign: 'left', transition: 'background 0.15s',
+            }}>
+            <Icon color={active ? '#e5e2e1' : '#aa8984'} />
+            {expanded && (
+              <span style={{ fontSize: 16, fontWeight: 500, letterSpacing: '0.8px', color: active ? '#e5e2e1' : '#aa8984', whiteSpace: 'nowrap' }}>
+                {label}
+              </span>
+            )}
+          </button>
+        ))}
+      </nav>
+    </aside>
+  );
+};
 
 const FinalRiddlePage = () => {
   const { gameId } = useParams();
-  const { loading, finalRiddle, gameStatus } = useFinalRiddle(gameId);
-  const { lettersLoading, letters } = useRevealedLetters(gameId);
+  const navigate = useNavigate();
+  const [sidebarExpanded, setSidebarExpanded] = useState(true);
   const [hasWon, setHasWon] = useState(false);
 
-  const navigate = useNavigate();
+  const { loading, finalRiddle } = useFinalRiddle(gameId);
+  const { lettersLoading, letters } = useRevealedLetters(gameId);
 
-  if (loading || lettersLoading) return <div className='min-h-screen flex items-center justify-center'>
-                            <span className="loading loading-spinner text-red-500"></span>
-                        </div>;
+  if (loading || lettersLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: '#131313' }}>
+        <p style={{ color: '#aa8984', fontSize: 10, letterSpacing: '1px' }}>LOADING...</p>
+      </div>
+    );
+  }
+
   if (!finalRiddle) return <GameNotFound />;
-  if (gameStatus !== 'final_riddle')
-    return <p className="text-red-500">Not in final riddle phase.</p>;
 
   if (hasWon) return <WinScreen onPlayAgain={() => navigate('/game/create')} />;
 
   return (
-      <div className='min-h-screen bg-gray-900'>
-        <FinalRiddle finalRiddle={finalRiddle} />
-          <RevealedLetters letters={letters} />
-          <FinalRiddleInput gameId={gameId} onCorrect={() => setHasWon(true)} />
+    <main className="flex min-h-screen" style={{ background: '#131313', color: '#e5e2e1', fontFamily: "'Space Grotesk', Helvetica, sans-serif" }}>
+
+      <Sidebar gameId={gameId} expanded={sidebarExpanded} onToggle={() => setSidebarExpanded(v => !v)} />
+
+      <section className="flex flex-col flex-1" style={{ minWidth: 0 }}>
+
+        {/* Header */}
+        <header className="flex items-center justify-between px-6 py-4" style={{ background: '#131313', borderBottom: '2px solid #1c1b1b' }}>
+          <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1' }}>ESCAPESNAP</span>
+        </header>
+
+        {/* Body */}
+        <div className="flex-1 p-8 flex flex-col gap-6">
+
+          {/* Title */}
+          <div className="flex items-center gap-3">
+            <div style={{ width: 4, height: 32, background: '#8b0000' }} />
+            <div>
+              <p style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>MISSION CRITICAL</p>
+              <h1 style={{ fontWeight: 700, fontSize: 28, letterSpacing: '2px', color: '#e5e2e1', lineHeight: 1.2 }}>
+                THE FINAL <span style={{ color: '#8b0000' }}>RIDDLE</span>
+              </h1>
+            </div>
+          </div>
+
+          {/* Riddle card */}
+          <div style={{ background: '#0e0e0e', borderLeft: '4px solid #8b0000', padding: '32px' }}>
+            <p style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984', marginBottom: 12 }}>DECRYPT THE CLUE</p>
+            <p style={{ fontSize: 22, fontWeight: 600, color: '#e5e2e1', lineHeight: 1.6, letterSpacing: '0.5px' }}>
+              "{finalRiddle}"
+            </p>
+          </div>
+
+          {/* Revealed Letters */}
+          <div style={{ background: '#1c1b1b', padding: '24px' }}>
+            <div className="flex items-center gap-3 mb-4">
+              <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+              <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>REVEALED LETTERS</span>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              {letters.map((letter, i) => (
+                <div key={i} style={{
+                  width: 64, height: 64,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  background: '#0e0e0e',
+                  borderBottom: '2px solid #8b0000',
+                  fontWeight: 700, fontSize: 24,
+                  color: '#e5e2e1', letterSpacing: '2px',
+                }}>
+                  {letter}
+                </div>
+              ))}
+              {letters.length === 0 && (
+                <p style={{ fontSize: 11, color: '#aa8984', opacity: 0.6 }}>NO LETTERS REVEALED YET</p>
+              )}
+            </div>
+          </div>
+
+          {/* Input */}
+          <div style={{ background: '#0e0e0e', padding: '24px' }}>
+            <div className="flex items-center gap-3 mb-4">
+              <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+              <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>SUBMIT ANSWER</span>
+            </div>
+            <FinalRiddleInput gameId={gameId} onCorrect={() => setHasWon(true)} />
+          </div>
+
         </div>
-    );
+      </section>
+    </main>
+  );
 };
 
 export default FinalRiddlePage;

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router';
 import { useFinalRiddle } from '/imports/ui/shared/hooks/useFinalRiddle.js';
 import { useRevealedLetters } from '/imports/ui/shared/hooks/useRevealedLetters.js';
 import GameNotFound from '/imports/ui/shared/components/GameNotFound.jsx';
+import RevealedLetters from '/imports/ui/host/components/riddle/RevealedLetters.jsx';
 
 const FinalRiddlePage = () => {
   const { gameId } = useParams();
@@ -19,8 +20,7 @@ const FinalRiddlePage = () => {
   return (
     <div>
       THIS IS THE FINAL RIDDLE PAGE
-      <p></p>
-      {letters}
+      <RevealedLetters letters={letters} />
     </div>
   );
 };

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router';
 import { useFinalRiddle } from '/imports/ui/shared/hooks/useFinalRiddle.js';
 import GameNotFound from '/imports/ui/shared/components/GameNotFound.jsx';
 import FinalRiddle from '/imports/ui/host/components/riddle/FinalRiddle.jsx';
+import FinalRiddleInput from '/imports/ui/host/components/riddle/FinalRiddleInput.jsx';
 
 const FinalRiddlePage = () => {
   const { gameId } = useParams();
@@ -19,6 +20,7 @@ const FinalRiddlePage = () => {
     <div className='min-h-screen'>
       THIS IS THE FINAL RIDDLE PAGE
       <FinalRiddle finalRiddle={finalRiddle} />
+      <FinalRiddleInput gameId={gameId}/>
     </div>
   );
 };

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -24,13 +24,12 @@ const FinalRiddlePage = () => {
   if (hasWon) return <WinScreen onPlayAgain={() => setHasWon(false)} />;
 
   return (
-    <div className='min-h-screen'>
-      THIS IS THE FINAL RIDDLE PAGE
-      <FinalRiddle finalRiddle={finalRiddle} />
-      <RevealedLetters letters={letters} />
-      <FinalRiddleInput gameId={gameId} onCorrect={() => setHasWon(true)} />
-    </div>
-  );
+      <div className='min-h-screen bg-gray-900'>
+        <FinalRiddle finalRiddle={finalRiddle} />
+          <RevealedLetters letters={letters} />
+          <FinalRiddleInput gameId={gameId} onCorrect={() => setHasWon(true)} />
+        </div>
+    );
 };
 
 export default FinalRiddlePage;

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -1,11 +1,22 @@
-import React from 'react'
+import React from 'react';
+import { useParams } from 'react-router';
+import { useFinalRiddle } from '/imports/ui/shared/hooks/useFinalRiddle.js';
+import GameNotFound from '/imports/ui/shared/components/GameNotFound.jsx';
 
 const FinalRiddlePage = () => {
+  const { gameId } = useParams();
+  const { loading, finalRiddle, gameStatus } = useFinalRiddle(gameId);
+
+  if (loading) return <p className="text-white">Loading...</p>;
+  if (!finalRiddle) return <GameNotFound />;
+  if (gameStatus !== 'final_riddle')
+    return <p className="text-red-500">Not in final riddle phase.</p>;
+
   return (
     <div>
       THIS IS THE FINAL RIDDLE PAGE
     </div>
-  )
-}
+  );
+};
 
-export default FinalRiddlePage
+export default FinalRiddlePage;

--- a/imports/ui/shared/components/GameNotFound.jsx
+++ b/imports/ui/shared/components/GameNotFound.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+const GameNotFound = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <h1 className="text-red-500 font-bold text-7xl uppercase tracking-widest">
+        Game Not Found.
+      </h1>
+    </div>
+  )
+}
+
+export default GameNotFound

--- a/imports/ui/shared/hooks/useFinalRiddle.js
+++ b/imports/ui/shared/hooks/useFinalRiddle.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
-import { Games } from '../../../api/games/GamesCollection';
+import { Games } from '/imports/api/games/GamesCollection';
 
 export function useFinalRiddle(gameId) {
   return useTracker(() => {

--- a/imports/ui/shared/hooks/useFinalRiddle.js
+++ b/imports/ui/shared/hooks/useFinalRiddle.js
@@ -1,0 +1,15 @@
+import { Meteor } from 'meteor/meteor';
+import { useTracker } from 'meteor/react-meteor-data';
+import { Games } from '../../../api/games/GamesCollection';
+
+export function useFinalRiddle(gameId) {
+  return useTracker(() => {
+    const sub = Meteor.subscribe('games.current', gameId);
+    const game = Games.findOne(gameId);
+    return {
+      loading: !sub.ready(),
+      finalRiddle: game?.finalRiddle ?? null,
+      gameStatus: game?.status ?? null,
+    };
+  }, [gameId]);
+}

--- a/imports/ui/shared/hooks/useFinalRiddle.js
+++ b/imports/ui/shared/hooks/useFinalRiddle.js
@@ -8,7 +8,7 @@ export function useFinalRiddle(gameId) {
     const game = Games.findOne(gameId);
     return {
       loading: !sub.ready(),
-      finalRiddle: game?.finalRiddle ?? null,
+      finalRiddle: game?.finalRiddle.riddle ?? null,
       gameStatus: game?.status ?? null,
     };
   }, [gameId]);

--- a/imports/ui/shared/hooks/useRevealedLetters.js
+++ b/imports/ui/shared/hooks/useRevealedLetters.js
@@ -1,0 +1,15 @@
+import { Meteor } from 'meteor/meteor';
+import { useTracker } from 'meteor/react-meteor-data';
+import { Games } from '../../../api/games/GamesCollection';
+
+export function useRevealedLetters(gameId) {
+  return useTracker(() => {
+    const sub = Meteor.subscribe('games.current', gameId);
+    const game = Games.findOne(gameId);
+    return {
+      loading: !sub.ready(),
+      // flat array of all letters collected across all players e.g. ["E", "?", "A", "T"]
+      letters: game?.players?.flatMap(p => p.revealedLetters ?? []) ?? [],
+    };
+  }, [gameId]);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "postcss-load-config": "^6.0.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-router": "^6.30.3",
+        "react-router-dom": "^6.30.3",
         "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
@@ -646,6 +648,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -5129,6 +5140,38 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@babel/runtime": "^7.23.5",
         "@tailwindcss/postcss": "^4.2.2",
+        "daisyui": "^5.5.19",
         "meteor-node-stubs": "^1.2.12",
         "postcss": "^8.5.6",
         "postcss-load-config": "^6.0.1",
@@ -1380,6 +1381,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/daisyui": {
+      "version": "5.5.19",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.19.tgz",
+      "integrity": "sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
       }
     },
     "node_modules/data-view-buffer": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.5",
     "@tailwindcss/postcss": "^4.2.2",
+    "daisyui": "^5.5.19",
     "meteor-node-stubs": "^1.2.12",
     "postcss": "^8.5.6",
     "postcss-load-config": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -14,16 +14,18 @@
     "postcss-load-config": "^6.0.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-router": "^6.30.3",
+    "react-router-dom": "^6.30.3",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.28.6",
     "@eslint/js": "^9.39.4",
     "eslint": "^9.39.4",
-    "globals": "^16.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react": "^7.37.5",
+    "globals": "^16.0.0",
     "prettier": "^3.8.3"
   }
 }

--- a/server/main.js
+++ b/server/main.js
@@ -4,20 +4,5 @@ import '../imports/api/games/gamesPublications';
 import { Games } from '../imports/api/games/GamesCollection';
 import { FINAL_RIDDLE } from '../imports/lib/finalRiddle';
 
-Meteor.startup(async () => {
-  const count = await Games.find().countAsync();
-  if (count === 0) {
-    await Games.insertAsync({
-      status: 'final_riddle',
-      createdAt: new Date(),
-      players: [
-        { id: 'player1', name: 'Dylan', revealedLetters: ['M', '?', 'A'] },
-      ],
-      finalRiddle: FINAL_RIDDLE,
-    });
-  } else {
-    const game = await Games.findOneAsync({ status: 'final_riddle' });
-    console.log('GAME ALREADY EXISTS', game);
-  }
-});
+Meteor.startup(async () => {});
 

--- a/server/main.js
+++ b/server/main.js
@@ -1,5 +1,23 @@
 import { Meteor } from 'meteor/meteor';
+import '../imports/api/games/gamesMethods';
+import '../imports/api/games/gamesPublications';
+import { Games } from '../imports/api/games/GamesCollection';
+import { FINAL_RIDDLE } from '../imports/lib/finalRiddle';
 
-Meteor.startup(() => {
-  // Server startup
+Meteor.startup(async () => {
+  const count = await Games.find().countAsync();
+  if (count === 0) {
+    await Games.insertAsync({
+      status: 'final_riddle',
+      createdAt: new Date(),
+      players: [
+        { id: 'player1', name: 'Dylan', revealedLetters: ['M', '?', 'A'] },
+      ],
+      finalRiddle: FINAL_RIDDLE,
+    });
+  } else {
+    const game = await Games.findOneAsync({ status: 'final_riddle' });
+    console.log('GAME ALREADY EXISTS', game);
+  }
 });
+


### PR DESCRIPTION
## What does this PR do?
- Added collapsible sidebar to the Final Riddle page matching the Progress page style
- Restyled Final Riddle page to match the dark theme (#131313 background, red accents)
- Restyled the answer input and submit button to match the dark theme
- Sidebar now has OPERATIVES and FINAL RIDDLE nav items with working navigation between pages
- Removed status guard that was blocking navigation to the Final Riddle page

## Type of change
- [x] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Config / setup

## How to test
1. Create a game and start it from the lobby
2. On the progress page, click FINAL RIDDLE in the sidebar
3. Verify you land on the Final Riddle page with the dark theme
4. Verify the sidebar shows FINAL RIDDLE as active
5. Click OPERATIVES to navigate back to the progress page
6. Verify the sidebar collapse/expand button works on both pages

## Screenshot
<img width="1919" height="908" alt="image" src="https://github.com/user-attachments/assets/c3e3a05b-b712-41a0-81bc-0b5597521465" />

## Checklist
- [x] Code runs locally with no errors
- [x] Follows project folder structure
- [ ] No console.log left in code
- [ ] Lint passes (meteor npm run lint)
