### PR TITLE
Fix/sidebar

### DIFF
--- a/imports/ui/host/components/riddle/FinalRiddleInput.jsx
+++ b/imports/ui/host/components/riddle/FinalRiddleInput.jsx
@@ -23,25 +23,48 @@ const FinalRiddleInput = ({ gameId, onCorrect = () => {} }) => {
   }
 
   return (
-    <div className='min-w-screen px-12'>
+    <div className="flex flex-col gap-3">
       <input
         type="text"
-        placeholder="Input riddle guess..."
-        className="w-full bg-gray-900 border-gray-200 min-h-15 input input-lg text-gray-500 text-2xl font-extraitalic"
+        placeholder="TYPE YOUR ANSWER..."
+        value={guess}
         onChange={e => setGuess(e.target.value)}
+        onKeyDown={e => e.key === 'Enter' && handleSubmit()}
+        style={{
+          width: '100%',
+          background: '#131313',
+          border: '1px solid #353534',
+          padding: '14px 16px',
+          color: '#e5e2e1',
+          fontSize: 14,
+          letterSpacing: '1px',
+          outline: 'none',
+          fontFamily: "'Space Grotesk', Helvetica, sans-serif",
+        }}
       />
       <button
-        className="w-full min-h-15 btn bg-red-600 mt-1 font-italic text-2xl"
         onClick={handleSubmit}
+        style={{
+          width: '100%',
+          padding: '14px',
+          background: '#8b0000',
+          color: '#e5e2e1',
+          fontWeight: 700,
+          fontSize: 13,
+          letterSpacing: '1.5px',
+          cursor: 'pointer',
+          transition: 'background 0.15s',
+          fontFamily: "'Space Grotesk', Helvetica, sans-serif",
+        }}
+        onMouseEnter={e => (e.currentTarget.style.background = '#a50000')}
+        onMouseLeave={e => (e.currentTarget.style.background = '#8b0000')}
       >
-        Make Guess
+        SUBMIT ANSWER
       </button>
 
       {result === 'incorrect' && (
-        <div className="toast toast-center toast-middle">
-          <div className="alert alert-error">
-            <span>Incorrect Guess.</span>
-          </div>
+        <div style={{ padding: '12px 16px', background: '#1c0000', borderLeft: '3px solid #8b0000' }}>
+          <p style={{ fontSize: 12, color: '#ffdad6', letterSpacing: '1px' }}>INCORRECT - TRY AGAIN</p>
         </div>
       )}
     </div>

--- a/imports/ui/host/pages/progress/ProgressPage.jsx
+++ b/imports/ui/host/pages/progress/ProgressPage.jsx
@@ -77,9 +77,8 @@ const Sidebar = ({ gameId, expanded, onToggle }) => {
   const navigate = useNavigate();
 
   const navItems = [
-    { label: 'DASHBOARD', Icon: DashboardIcon, route: '/', active: false },
     { label: 'OPERATIVES', Icon: OperativesIcon, route: `/game/${gameId}/progress`, active: true },
-    { label: 'LOGS', Icon: LogsIcon, route: null, active: false },
+    { label: 'FINAL RIDDLE', Icon: RiddleIcon, route: `/game/${gameId}/final-riddle`, active: false },
   ];
 
   return (

--- a/imports/ui/host/pages/progress/ProgressPage.jsx
+++ b/imports/ui/host/pages/progress/ProgressPage.jsx
@@ -222,26 +222,6 @@ const ProgressPage = () => {
             <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1' }}>ESCAPESNAP</span>
             <div style={{ width: 1, height: 16, background: '#5a403c', opacity: 0.3 }} />
           </div>
-          <div className="flex items-center gap-3">
-            <div className="flex items-center gap-2 px-3 py-1" style={{ background: '#0e0e0e', border: '1px solid rgba(90,64,60,0.1)' }}>
-              <span style={{ fontSize: 10, color: '#aa8984' }}>PIN:</span>
-              <span style={{ fontWeight: 700, fontSize: 14, letterSpacing: '1.4px', color: '#e5e2e1' }}>{pin}</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <circle cx="9" cy="9" r="7" stroke="#aa8984" strokeWidth="1.5" />
-                <polyline points="9,5 9,9 12,11" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <circle cx="9" cy="6" r="3" stroke="#aa8984" strokeWidth="1.5" />
-                <path d="M3 16c0-3.314 2.686-6 6-6s6 2.686 6 6" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
-              </svg>
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <path d="M9 2C6.24 2 4 4.24 4 7v5l-1.5 1.5V15h13v-1.5L14 12V7c0-2.76-2.24-5-5-5z" stroke="#aa8984" strokeWidth="1.5" strokeLinejoin="round" />
-                <path d="M7 15a2 2 0 004 0" stroke="#aa8984" strokeWidth="1.5" />
-              </svg>
-            </div>
-          </div>
         </header>
 
         {/* Body */}

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -1,39 +1,188 @@
 import React, { useState } from 'react';
-import { useParams } from 'react-router';
+import { useParams, useNavigate } from 'react-router';
 import { useFinalRiddle } from '/imports/ui/shared/hooks/useFinalRiddle.js';
 import { useRevealedLetters } from '/imports/ui/shared/hooks/useRevealedLetters.js';
-import { useNavigate } from 'react-router';
-
 import GameNotFound from '/imports/ui/shared/components/GameNotFound.jsx';
-import RevealedLetters from '/imports/ui/host/components/riddle/RevealedLetters.jsx';
-import FinalRiddle from '/imports/ui/host/components/riddle/FinalRiddle.jsx';
-import FinalRiddleInput from '/imports/ui/host/components/riddle/FinalRiddleInput.jsx';
 import WinScreen from '/imports/ui/host/pages/game-completion/WinScreen.jsx';
+import FinalRiddleInput from '/imports/ui/host/components/riddle/FinalRiddleInput.jsx';
+
+const HamburgerIcon = () => (
+  <svg width="18" height="14" viewBox="0 0 18 14" fill="none" style={{ flexShrink: 0 }}>
+    <line x1="0" y1="1" x2="18" y2="1" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="0" y1="7" x2="18" y2="7" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="0" y1="13" x2="18" y2="13" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const OperativesIcon = ({ color }) => (
+  <svg width="19" height="20" viewBox="0 0 19 20" fill="none" style={{ flexShrink: 0 }}>
+    <circle cx="9.5" cy="10" r="8" stroke={color} strokeWidth="1.5" />
+    <circle cx="9.5" cy="10" r="3" stroke={color} strokeWidth="1.5" />
+    <line x1="9.5" y1="1" x2="9.5" y2="4" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="9.5" y1="16" x2="9.5" y2="19" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="1" y1="10" x2="4" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="15" y1="10" x2="18" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const RiddleIcon = ({ color }) => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ flexShrink: 0 }}>
+    <path d="M9 1L11.5 6.5L17 7.3L13 11.2L14 17L9 14.3L4 17L5 11.2L1 7.3L6.5 6.5L9 1Z" stroke={color} strokeWidth="1.5" strokeLinejoin="round" />
+  </svg>
+);
+
+const Sidebar = ({ gameId, expanded, onToggle }) => {
+  const navigate = useNavigate();
+
+  const navItems = [
+    { label: 'OPERATIVES', Icon: OperativesIcon, route: `/game/${gameId}/progress`, active: false },
+    { label: 'FINAL RIDDLE', Icon: RiddleIcon, route: `/game/${gameId}/final-riddle`, active: true },
+  ];
+
+  return (
+    <aside style={{
+      width: expanded ? 200 : 60,
+      minHeight: '100vh',
+      background: '#0e0e0e',
+      borderRight: '1px solid #1c1b1b',
+      display: 'flex',
+      flexDirection: 'column',
+      transition: 'width 0.25s ease',
+      overflow: 'hidden',
+      flexShrink: 0,
+    }}>
+      <div style={{ borderBottom: '1px solid #1c1b1b', display: 'flex', alignItems: 'center', justifyContent: expanded ? 'space-between' : 'center', padding: expanded ? '20px 16px 20px 24px' : '20px 0' }}>
+        {expanded && (
+          <div>
+            <div style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1', whiteSpace: 'nowrap' }}>GAME</div>
+            <div style={{ fontWeight: 500, fontSize: 10, letterSpacing: '0.5px', color: '#8b0000', marginTop: 2, whiteSpace: 'nowrap' }}>FINAL RIDDLE</div>
+          </div>
+        )}
+        <button onClick={onToggle} title={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
+          style={{ background: 'transparent', cursor: 'pointer', opacity: 0.5, padding: 4, display: 'flex', alignItems: 'center' }}>
+          <HamburgerIcon />
+        </button>
+      </div>
+
+      <nav style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        {navItems.map(({ label, Icon, route, active }) => (
+          <button key={label} onClick={() => route && navigate(route)} title={!expanded ? label : undefined}
+            style={{
+              display: 'flex', alignItems: 'center',
+              gap: expanded ? 16 : 0,
+              justifyContent: expanded ? 'flex-start' : 'center',
+              padding: expanded ? '16px 24px' : '16px 0',
+              background: active ? '#1c1b1b' : 'transparent',
+              borderLeft: active ? '2px solid #8b0000' : '2px solid transparent',
+              cursor: 'pointer', opacity: active ? 1 : 0.7,
+              width: '100%', textAlign: 'left', transition: 'background 0.15s',
+            }}>
+            <Icon color={active ? '#e5e2e1' : '#aa8984'} />
+            {expanded && (
+              <span style={{ fontSize: 16, fontWeight: 500, letterSpacing: '0.8px', color: active ? '#e5e2e1' : '#aa8984', whiteSpace: 'nowrap' }}>
+                {label}
+              </span>
+            )}
+          </button>
+        ))}
+      </nav>
+    </aside>
+  );
+};
 
 const FinalRiddlePage = () => {
   const { gameId } = useParams();
-  const { loading, finalRiddle, gameStatus } = useFinalRiddle(gameId);
-  const { lettersLoading, letters } = useRevealedLetters(gameId);
+  const navigate = useNavigate();
+  const [sidebarExpanded, setSidebarExpanded] = useState(true);
   const [hasWon, setHasWon] = useState(false);
 
-  const navigate = useNavigate();
+  const { loading, finalRiddle } = useFinalRiddle(gameId);
+  const { lettersLoading, letters } = useRevealedLetters(gameId);
 
-  if (loading || lettersLoading) return <div className='min-h-screen flex items-center justify-center'>
-                            <span className="loading loading-spinner text-red-500"></span>
-                        </div>;
+  if (loading || lettersLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: '#131313' }}>
+        <p style={{ color: '#aa8984', fontSize: 10, letterSpacing: '1px' }}>LOADING...</p>
+      </div>
+    );
+  }
+
   if (!finalRiddle) return <GameNotFound />;
-  if (gameStatus !== 'final_riddle')
-    return <p className="text-red-500">Not in final riddle phase.</p>;
 
   if (hasWon) return <WinScreen onPlayAgain={() => navigate('/game/create')} />;
 
   return (
-      <div className='min-h-screen bg-gray-900'>
-        <FinalRiddle finalRiddle={finalRiddle} />
-          <RevealedLetters letters={letters} />
-          <FinalRiddleInput gameId={gameId} onCorrect={() => setHasWon(true)} />
+    <main className="flex min-h-screen" style={{ background: '#131313', color: '#e5e2e1', fontFamily: "'Space Grotesk', Helvetica, sans-serif" }}>
+
+      <Sidebar gameId={gameId} expanded={sidebarExpanded} onToggle={() => setSidebarExpanded(v => !v)} />
+
+      <section className="flex flex-col flex-1" style={{ minWidth: 0 }}>
+
+        {/* Header */}
+        <header className="flex items-center justify-between px-6 py-4" style={{ background: '#131313', borderBottom: '2px solid #1c1b1b' }}>
+          <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1' }}>ESCAPESNAP</span>
+        </header>
+
+        {/* Body */}
+        <div className="flex-1 p-8 flex flex-col gap-6">
+
+          {/* Title */}
+          <div className="flex items-center gap-3">
+            <div style={{ width: 4, height: 32, background: '#8b0000' }} />
+            <div>
+              <p style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>MISSION CRITICAL</p>
+              <h1 style={{ fontWeight: 700, fontSize: 28, letterSpacing: '2px', color: '#e5e2e1', lineHeight: 1.2 }}>
+                THE FINAL <span style={{ color: '#8b0000' }}>RIDDLE</span>
+              </h1>
+            </div>
+          </div>
+
+          {/* Riddle card */}
+          <div style={{ background: '#0e0e0e', borderLeft: '4px solid #8b0000', padding: '32px' }}>
+            <p style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984', marginBottom: 12 }}>DECRYPT THE CLUE</p>
+            <p style={{ fontSize: 22, fontWeight: 600, color: '#e5e2e1', lineHeight: 1.6, letterSpacing: '0.5px' }}>
+              "{finalRiddle}"
+            </p>
+          </div>
+
+          {/* Revealed Letters */}
+          <div style={{ background: '#1c1b1b', padding: '24px' }}>
+            <div className="flex items-center gap-3 mb-4">
+              <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+              <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>REVEALED LETTERS</span>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              {letters.map((letter, i) => (
+                <div key={i} style={{
+                  width: 64, height: 64,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  background: '#0e0e0e',
+                  borderBottom: '2px solid #8b0000',
+                  fontWeight: 700, fontSize: 24,
+                  color: '#e5e2e1', letterSpacing: '2px',
+                }}>
+                  {letter}
+                </div>
+              ))}
+              {letters.length === 0 && (
+                <p style={{ fontSize: 11, color: '#aa8984', opacity: 0.6 }}>NO LETTERS REVEALED YET</p>
+              )}
+            </div>
+          </div>
+
+          {/* Input */}
+          <div style={{ background: '#0e0e0e', padding: '24px' }}>
+            <div className="flex items-center gap-3 mb-4">
+              <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+              <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>SUBMIT ANSWER</span>
+            </div>
+            <FinalRiddleInput gameId={gameId} onCorrect={() => setHasWon(true)} />
+          </div>
+
         </div>
-    );
+      </section>
+    </main>
+  );
 };
 
 export default FinalRiddlePage;


### PR DESCRIPTION
## What does this PR do?
- Added collapsible sidebar to the Final Riddle page matching the Progress page style
- Restyled Final Riddle page to match the dark theme (#131313 background, red accents)
- Restyled the answer input and submit button to match the dark theme
- Sidebar now has OPERATIVES and FINAL RIDDLE nav items with working navigation between pages
- Removed status guard that was blocking navigation to the Final Riddle page

## Type of change
- [x] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Config / setup

## How to test
1. Create a game and start it from the lobby
2. On the progress page, click FINAL RIDDLE in the sidebar
3. Verify you land on the Final Riddle page with the dark theme
4. Verify the sidebar shows FINAL RIDDLE as active
5. Click OPERATIVES to navigate back to the progress page
6. Verify the sidebar collapse/expand button works on both pages

## Screenshot
<img width="1919" height="908" alt="image" src="https://github.com/user-attachments/assets/c3e3a05b-b712-41a0-81bc-0b5597521465" />

## Checklist
- [x] Code runs locally with no errors
- [x] Follows project folder structure
- [ ] No console.log left in code
- [ ] Lint passes (meteor npm run lint)
