### PR TITLE
Fix/sidebar

### DIFF
--- a/imports/api/games/gamesMethods.js
+++ b/imports/api/games/gamesMethods.js
@@ -32,8 +32,8 @@ Meteor.methods({
   async 'games.submitFinalAnswer'(gameId, guess) {
     const game = await Games.findOneAsync(gameId);
     if (!game) throw new Meteor.Error('not-found', 'Game not found');
-    if (game.status !== 'final_riddle')
-      throw new Meteor.Error('invalid-state', 'Game is not in final riddle phase');
+    if (game.status !== 'in_progress')
+      throw new Meteor.Error('invalid-state', 'Game is not in progress');
 
     // Sprint 3: move answer validation server-side only so answer is never sent to client
     const isCorrect =
@@ -41,7 +41,7 @@ Meteor.methods({
 
     await Games.updateAsync(gameId, {
       $set: {
-        // status: isCorrect ? 'won' : 'lost',
+        status: 'ended',
         endedAt: new Date(),
       },
     });

--- a/imports/api/games/gamesMethods.js
+++ b/imports/api/games/gamesMethods.js
@@ -35,17 +35,23 @@ Meteor.methods({
     if (game.status !== 'in_progress')
       throw new Meteor.Error('invalid-state', 'Game is not in progress');
 
+    const MAX_ATTEMPTS = 3;
+    const attempts = (game.finalRiddleAttempts ?? 0) + 1;
+
     // Sprint 3: move answer validation server-side only so answer is never sent to client
     const isCorrect =
       guess.trim().toLowerCase() === game.finalRiddle.answer.toLowerCase();
 
-    await Games.updateAsync(gameId, {
-      $set: {
-        status: 'ended',
-        endedAt: new Date(),
-      },
-    });
+    if (isCorrect || attempts >= MAX_ATTEMPTS) {
+      await Games.updateAsync(gameId, {
+        $set: { status: 'ended', endedAt: new Date(), finalRiddleAttempts: attempts },
+      });
+    } else {
+      await Games.updateAsync(gameId, {
+        $set: { finalRiddleAttempts: attempts },
+      });
+    }
 
-    return isCorrect;
+    return { isCorrect, attemptsLeft: isCorrect ? 0 : MAX_ATTEMPTS - attempts };
   },
 });

--- a/imports/ui/host/components/riddle/FinalRiddleInput.jsx
+++ b/imports/ui/host/components/riddle/FinalRiddleInput.jsx
@@ -4,19 +4,25 @@ import { Meteor } from 'meteor/meteor';
 const FinalRiddleInput = ({ gameId, onCorrect = () => {} }) => {
   const [guess, setGuess] = useState('');
   const [result, setResult] = useState(null);
+  const [attemptsLeft, setAttemptsLeft] = useState(3);
 
   useEffect(() => {
-    if (!result) return;
+    if (!result || result === 'correct') return;
     const timer = setTimeout(() => setResult(null), 3000);
     return () => clearTimeout(timer);
   }, [result]);
 
+  const exhausted = attemptsLeft === 0;
+
   function handleSubmit() {
-    Meteor.call('games.submitFinalAnswer', gameId, guess, (error, isCorrect) => {
+    if (!guess.trim() || exhausted) return;
+    Meteor.call('games.submitFinalAnswer', gameId, guess, (error, response) => {
       if (error) {
         console.error(error);
         return;
       }
+      const { isCorrect, attemptsLeft: remaining } = response;
+      setAttemptsLeft(remaining);
       setResult(isCorrect ? 'correct' : 'incorrect');
       if (isCorrect) onCorrect();
     });
@@ -26,45 +32,56 @@ const FinalRiddleInput = ({ gameId, onCorrect = () => {} }) => {
     <div className="flex flex-col gap-3">
       <input
         type="text"
-        placeholder="TYPE YOUR ANSWER..."
+        placeholder={exhausted ? 'NO ATTEMPTS REMAINING' : 'TYPE YOUR ANSWER...'}
         value={guess}
+        disabled={exhausted}
         onChange={e => setGuess(e.target.value)}
         onKeyDown={e => e.key === 'Enter' && handleSubmit()}
         style={{
           width: '100%',
-          background: '#131313',
+          background: exhausted ? '#0a0a0a' : '#131313',
           border: '1px solid #353534',
           padding: '14px 16px',
-          color: '#e5e2e1',
+          color: exhausted ? '#555' : '#e5e2e1',
           fontSize: 14,
           letterSpacing: '1px',
           outline: 'none',
           fontFamily: "'Space Grotesk', Helvetica, sans-serif",
+          cursor: exhausted ? 'not-allowed' : 'text',
         }}
       />
       <button
         onClick={handleSubmit}
+        disabled={exhausted}
         style={{
           width: '100%',
           padding: '14px',
-          background: '#8b0000',
-          color: '#e5e2e1',
+          background: exhausted ? '#3a0000' : '#8b0000',
+          color: exhausted ? '#555' : '#e5e2e1',
           fontWeight: 700,
           fontSize: 13,
           letterSpacing: '1.5px',
-          cursor: 'pointer',
+          cursor: exhausted ? 'not-allowed' : 'pointer',
           transition: 'background 0.15s',
           fontFamily: "'Space Grotesk', Helvetica, sans-serif",
+          opacity: exhausted ? 0.5 : 1,
         }}
-        onMouseEnter={e => (e.currentTarget.style.background = '#a50000')}
-        onMouseLeave={e => (e.currentTarget.style.background = '#8b0000')}
+        onMouseEnter={e => { if (!exhausted) e.currentTarget.style.background = '#a50000'; }}
+        onMouseLeave={e => { if (!exhausted) e.currentTarget.style.background = '#8b0000'; }}
       >
         SUBMIT ANSWER
       </button>
 
-      {result === 'incorrect' && (
-        <div style={{ padding: '12px 16px', background: '#1c0000', borderLeft: '3px solid #8b0000' }}>
+      {result === 'incorrect' && !exhausted && (
+        <div style={{ padding: '12px 16px', background: '#1c0000', borderLeft: '3px solid #8b0000', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <p style={{ fontSize: 12, color: '#ffdad6', letterSpacing: '1px' }}>INCORRECT - TRY AGAIN</p>
+          <p style={{ fontSize: 11, color: '#aa8984', letterSpacing: '1px' }}>{attemptsLeft} {attemptsLeft === 1 ? 'ATTEMPT' : 'ATTEMPTS'} LEFT</p>
+        </div>
+      )}
+
+      {exhausted && (
+        <div style={{ padding: '12px 16px', background: '#1c0000', borderLeft: '3px solid #ff0000' }}>
+          <p style={{ fontSize: 12, color: '#ffdad6', letterSpacing: '1px' }}>MISSION FAILED - NO ATTEMPTS REMAINING</p>
         </div>
       )}
     </div>

--- a/imports/ui/host/components/riddle/FinalRiddleInput.jsx
+++ b/imports/ui/host/components/riddle/FinalRiddleInput.jsx
@@ -23,25 +23,48 @@ const FinalRiddleInput = ({ gameId, onCorrect = () => {} }) => {
   }
 
   return (
-    <div className='min-w-screen px-12'>
+    <div className="flex flex-col gap-3">
       <input
         type="text"
-        placeholder="Input riddle guess..."
-        className="w-full bg-gray-900 border-gray-200 min-h-15 input input-lg text-gray-500 text-2xl font-extraitalic"
+        placeholder="TYPE YOUR ANSWER..."
+        value={guess}
         onChange={e => setGuess(e.target.value)}
+        onKeyDown={e => e.key === 'Enter' && handleSubmit()}
+        style={{
+          width: '100%',
+          background: '#131313',
+          border: '1px solid #353534',
+          padding: '14px 16px',
+          color: '#e5e2e1',
+          fontSize: 14,
+          letterSpacing: '1px',
+          outline: 'none',
+          fontFamily: "'Space Grotesk', Helvetica, sans-serif",
+        }}
       />
       <button
-        className="w-full min-h-15 btn bg-red-600 mt-1 font-italic text-2xl"
         onClick={handleSubmit}
+        style={{
+          width: '100%',
+          padding: '14px',
+          background: '#8b0000',
+          color: '#e5e2e1',
+          fontWeight: 700,
+          fontSize: 13,
+          letterSpacing: '1.5px',
+          cursor: 'pointer',
+          transition: 'background 0.15s',
+          fontFamily: "'Space Grotesk', Helvetica, sans-serif",
+        }}
+        onMouseEnter={e => (e.currentTarget.style.background = '#a50000')}
+        onMouseLeave={e => (e.currentTarget.style.background = '#8b0000')}
       >
-        Make Guess
+        SUBMIT ANSWER
       </button>
 
       {result === 'incorrect' && (
-        <div className="toast toast-center toast-middle">
-          <div className="alert alert-error">
-            <span>Incorrect Guess.</span>
-          </div>
+        <div style={{ padding: '12px 16px', background: '#1c0000', borderLeft: '3px solid #8b0000' }}>
+          <p style={{ fontSize: 12, color: '#ffdad6', letterSpacing: '1px' }}>INCORRECT - TRY AGAIN</p>
         </div>
       )}
     </div>

--- a/imports/ui/host/layouts/SidebarLayout.jsx
+++ b/imports/ui/host/layouts/SidebarLayout.jsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router';
+
+const HamburgerIcon = () => (
+  <svg width="18" height="14" viewBox="0 0 18 14" fill="none" style={{ flexShrink: 0 }}>
+    <line x1="0" y1="1" x2="18" y2="1" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="0" y1="7" x2="18" y2="7" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="0" y1="13" x2="18" y2="13" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const OperativesIcon = ({ color }) => (
+  <svg width="19" height="20" viewBox="0 0 19 20" fill="none" style={{ flexShrink: 0 }}>
+    <circle cx="9.5" cy="10" r="8" stroke={color} strokeWidth="1.5" />
+    <circle cx="9.5" cy="10" r="3" stroke={color} strokeWidth="1.5" />
+    <line x1="9.5" y1="1" x2="9.5" y2="4" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="9.5" y1="16" x2="9.5" y2="19" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="1" y1="10" x2="4" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="15" y1="10" x2="18" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const RiddleIcon = ({ color }) => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ flexShrink: 0 }}>
+    <path d="M9 1L11.5 6.5L17 7.3L13 11.2L14 17L9 14.3L4 17L5 11.2L1 7.3L6.5 6.5L9 1Z" stroke={color} strokeWidth="1.5" strokeLinejoin="round" />
+  </svg>
+);
+
+const NAV_ITEMS = [
+  { label: 'OPERATIVES', Icon: OperativesIcon, page: 'progress', path: (id) => `/game/${id}/progress` },
+  { label: 'FINAL RIDDLE', Icon: RiddleIcon, page: 'final-riddle', path: (id) => `/game/${id}/final-riddle` },
+];
+
+const SUBTITLES = {
+  progress: 'LOBBY',
+  'final-riddle': 'FINAL RIDDLE',
+};
+
+const Sidebar = ({ gameId, activePage, expanded, onToggle }) => {
+  const navigate = useNavigate();
+  const subtitle = SUBTITLES[activePage] ?? 'GAME';
+
+  return (
+    <aside style={{
+      width: expanded ? 200 : 60,
+      minHeight: '100vh',
+      background: '#0e0e0e',
+      borderRight: '1px solid #1c1b1b',
+      display: 'flex',
+      flexDirection: 'column',
+      transition: 'width 0.25s ease',
+      overflow: 'hidden',
+      flexShrink: 0,
+    }}>
+      <div style={{
+        borderBottom: '1px solid #1c1b1b',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: expanded ? 'space-between' : 'center',
+        padding: expanded ? '20px 16px 20px 24px' : '20px 0',
+      }}>
+        {expanded && (
+          <div>
+            <div style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1', whiteSpace: 'nowrap' }}>GAME</div>
+            <div style={{ fontWeight: 500, fontSize: 10, letterSpacing: '0.5px', color: '#8b0000', marginTop: 2, whiteSpace: 'nowrap' }}>{subtitle}</div>
+          </div>
+        )}
+        <button
+          onClick={onToggle}
+          title={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
+          style={{ background: 'transparent', cursor: 'pointer', opacity: 0.5, padding: 4, display: 'flex', alignItems: 'center' }}
+        >
+          <HamburgerIcon />
+        </button>
+      </div>
+
+      <nav style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        {NAV_ITEMS.map(({ label, Icon, page, path }) => {
+          const active = page === activePage;
+          return (
+            <button
+              key={label}
+              onClick={() => navigate(path(gameId))}
+              title={!expanded ? label : undefined}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: expanded ? 16 : 0,
+                justifyContent: expanded ? 'flex-start' : 'center',
+                padding: expanded ? '16px 24px' : '16px 0',
+                background: active ? '#1c1b1b' : 'transparent',
+                borderLeft: active ? '2px solid #8b0000' : '2px solid transparent',
+                cursor: 'pointer',
+                opacity: active ? 1 : 0.7,
+                width: '100%',
+                textAlign: 'left',
+                transition: 'background 0.15s',
+              }}
+            >
+              <Icon color={active ? '#e5e2e1' : '#aa8984'} />
+              {expanded && (
+                <span style={{ fontSize: 16, fontWeight: 500, letterSpacing: '0.8px', color: active ? '#e5e2e1' : '#aa8984', whiteSpace: 'nowrap' }}>
+                  {label}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+};
+
+const SidebarLayout = ({ gameId, activePage, children }) => {
+  const [sidebarExpanded, setSidebarExpanded] = useState(true);
+
+  return (
+    <main className="flex min-h-screen" style={{ background: '#131313', color: '#e5e2e1', fontFamily: "'Space Grotesk', Helvetica, sans-serif" }}>
+      <Sidebar
+        gameId={gameId}
+        activePage={activePage}
+        expanded={sidebarExpanded}
+        onToggle={() => setSidebarExpanded(v => !v)}
+      />
+      <section className="flex flex-col flex-1" style={{ minWidth: 0 }}>
+        {children}
+      </section>
+    </main>
+  );
+};
+
+export default SidebarLayout;

--- a/imports/ui/host/pages/progress/ProgressPage.jsx
+++ b/imports/ui/host/pages/progress/ProgressPage.jsx
@@ -77,9 +77,8 @@ const Sidebar = ({ gameId, expanded, onToggle }) => {
   const navigate = useNavigate();
 
   const navItems = [
-    { label: 'DASHBOARD', Icon: DashboardIcon, route: '/', active: false },
     { label: 'OPERATIVES', Icon: OperativesIcon, route: `/game/${gameId}/progress`, active: true },
-    { label: 'LOGS', Icon: LogsIcon, route: null, active: false },
+    { label: 'FINAL RIDDLE', Icon: RiddleIcon, route: `/game/${gameId}/final-riddle`, active: false },
   ];
 
   return (

--- a/imports/ui/host/pages/progress/ProgressPage.jsx
+++ b/imports/ui/host/pages/progress/ProgressPage.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router';
+import { useParams } from 'react-router';
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
 import { Games } from '../../../../api/games/GamesCollection';
+import SidebarLayout from '/imports/ui/host/layouts/SidebarLayout.jsx';
 
 const MOCK_PUZZLE_DATA = [
   { puzzles: [true, true, true, false, false], status: 'COMPLETED' },
@@ -30,128 +31,8 @@ const CrossIcon = () => (
   </svg>
 );
 
-const DashboardIcon = ({ color }) => (
-  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ flexShrink: 0 }}>
-    <rect x="1" y="1" width="6" height="6" rx="1" stroke={color} strokeWidth="1.5" />
-    <rect x="11" y="1" width="6" height="6" rx="1" stroke={color} strokeWidth="1.5" />
-    <rect x="1" y="11" width="6" height="6" rx="1" stroke={color} strokeWidth="1.5" />
-    <rect x="11" y="11" width="6" height="6" rx="1" stroke={color} strokeWidth="1.5" />
-  </svg>
-);
-
-const OperativesIcon = ({ color }) => (
-  <svg width="19" height="20" viewBox="0 0 19 20" fill="none" style={{ flexShrink: 0 }}>
-    <circle cx="9.5" cy="10" r="8" stroke={color} strokeWidth="1.5" />
-    <circle cx="9.5" cy="10" r="3" stroke={color} strokeWidth="1.5" />
-    <line x1="9.5" y1="1" x2="9.5" y2="4" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="9.5" y1="16" x2="9.5" y2="19" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="1" y1="10" x2="4" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="15" y1="10" x2="18" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
-  </svg>
-);
-
-const LogsIcon = ({ color }) => (
-  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ flexShrink: 0 }}>
-    <rect x="1" y="1" width="16" height="16" rx="2" stroke={color} strokeWidth="1.5" />
-    <line x1="4" y1="6" x2="14" y2="6" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="4" y1="9" x2="14" y2="9" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="4" y1="12" x2="10" y2="12" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
-  </svg>
-);
-
-const RiddleIcon = ({ color }) => (
-  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ flexShrink: 0 }}>
-    <path d="M9 1L11.5 6.5L17 7.3L13 11.2L14 17L9 14.3L4 17L5 11.2L1 7.3L6.5 6.5L9 1Z" stroke={color} strokeWidth="1.5" strokeLinejoin="round" />
-  </svg>
-);
-
-const HamburgerIcon = () => (
-  <svg width="18" height="14" viewBox="0 0 18 14" fill="none" style={{ flexShrink: 0 }}>
-    <line x1="0" y1="1" x2="18" y2="1" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="0" y1="7" x2="18" y2="7" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="0" y1="13" x2="18" y2="13" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
-  </svg>
-);
-
-const Sidebar = ({ gameId, expanded, onToggle }) => {
-  const navigate = useNavigate();
-
-  const navItems = [
-    { label: 'OPERATIVES', Icon: OperativesIcon, route: `/game/${gameId}/progress`, active: true },
-    { label: 'FINAL RIDDLE', Icon: RiddleIcon, route: `/game/${gameId}/final-riddle`, active: false },
-  ];
-
-  return (
-    <aside
-      style={{
-        width: expanded ? 200 : 60,
-        minHeight: '100vh',
-        background: '#0e0e0e',
-        borderRight: '1px solid #1c1b1b',
-        display: 'flex',
-        flexDirection: 'column',
-        transition: 'width 0.25s ease',
-        overflow: 'hidden',
-        flexShrink: 0,
-      }}
-    >
-      {/* Toggle button + Logo area */}
-      <div style={{ borderBottom: '1px solid #1c1b1b', display: 'flex', alignItems: 'center', justifyContent: expanded ? 'space-between' : 'center', padding: expanded ? '20px 16px 20px 24px' : '20px 0' }}>
-        {expanded && (
-          <div>
-            <div style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1', whiteSpace: 'nowrap' }}>GAME</div>
-            <div style={{ fontWeight: 500, fontSize: 10, letterSpacing: '0.5px', color: '#8b0000', marginTop: 2, whiteSpace: 'nowrap' }}>LOBBY</div>
-          </div>
-        )}
-        <button
-          onClick={onToggle}
-          title={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
-          style={{ background: 'transparent', cursor: 'pointer', opacity: 0.5, padding: 4, display: 'flex', alignItems: 'center' }}
-        >
-          <HamburgerIcon />
-        </button>
-      </div>
-
-      {/* Nav items */}
-      <nav style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
-        {navItems.map(({ label, Icon, route, active }) => (
-          <button
-            key={label}
-            onClick={() => route && navigate(route)}
-            title={!expanded ? label : undefined}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: expanded ? 16 : 0,
-              justifyContent: expanded ? 'flex-start' : 'center',
-              padding: expanded ? '16px 24px' : '16px 0',
-              background: active ? '#1c1b1b' : 'transparent',
-              borderLeft: active ? '2px solid #8b0000' : '2px solid transparent',
-              cursor: route ? 'pointer' : 'default',
-              opacity: active ? 1 : 0.7,
-              width: '100%',
-              textAlign: 'left',
-              transition: 'background 0.15s',
-            }}
-          >
-            <Icon color={active ? '#e5e2e1' : '#aa8984'} />
-            {expanded && (
-              <span style={{ fontSize: 16, fontWeight: 500, letterSpacing: '0.8px', color: active ? '#e5e2e1' : '#aa8984', whiteSpace: 'nowrap' }}>
-                {label}
-              </span>
-            )}
-          </button>
-        ))}
-      </nav>
-
-    </aside>
-  );
-};
-
 const ProgressPage = () => {
   const { gameId } = useParams();
-  const navigate = useNavigate();
-  const [sidebarExpanded, setSidebarExpanded] = useState(true);
   const [timeLeft, setTimeLeft] = useState(null);
 
   const { game, loading } = useTracker(() => {
@@ -208,134 +89,129 @@ const ProgressPage = () => {
   const isExpired = timeLeft === 0;
 
   return (
-    <main className="flex min-h-screen" style={{ background: '#131313', color: '#e5e2e1', fontFamily: "'Space Grotesk', Helvetica, sans-serif" }}>
+    <SidebarLayout gameId={gameId} activePage="progress">
 
-      <Sidebar gameId={gameId} expanded={sidebarExpanded} onToggle={() => setSidebarExpanded(v => !v)} />
-
-      {/* Main content */}
-      <section className="flex flex-col flex-1" style={{ minWidth: 0 }}>
-
-        {/* Header */}
-        <header className="flex items-center justify-between px-6 py-4" style={{ background: '#131313', borderBottom: '2px solid #1c1b1b' }}>
-          <div className="flex items-center gap-4">
-            <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1' }}>ESCAPESNAP</span>
-            <div style={{ width: 1, height: 16, background: '#5a403c', opacity: 0.3 }} />
-          </div>
-        </header>
-
-        {/* Body */}
-        <div className="flex-1 p-8 flex flex-col gap-8">
-
-          {/* Stats row */}
-          <div className="grid grid-cols-4" style={{ height: 160 }}>
-            <div className="flex flex-col justify-between p-6" style={{ background: '#0e0e0e', borderLeft: `2px solid ${isExpired ? '#ff0000' : '#8b0000'}` }}>
-              <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>TIME REMAINING</span>
-              <span style={{ fontWeight: 300, fontSize: 60, letterSpacing: '-3px', lineHeight: '60px', color: isExpired ? '#ff4444' : '#e5e2e1' }}>
-                {game.startedAt ? formatTime(timeLeft) : '--:--'}
-              </span>
-              {!game.startedAt && (
-                <span style={{ fontSize: 9, color: '#aa8984', opacity: 0.6, letterSpacing: '0.5px' }}>GAME NOT STARTED</span>
-              )}
-            </div>
-
-            <div className="flex flex-col justify-between p-6" style={{ background: '#1c1b1b' }}>
-              <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>TEAM PROGRESS</span>
-              <div className="flex items-end gap-2">
-                <span style={{ fontWeight: 700, fontSize: 48, lineHeight: '48px', color: '#e5e2e1' }}>64</span>
-                <span style={{ fontSize: 24, color: '#aa8984', paddingBottom: 4 }}>%</span>
-              </div>
-              <div style={{ height: 4, background: '#353534' }}>
-                <div style={{ height: '100%', width: '64%', background: '#8b0000' }} />
-              </div>
-            </div>
-
-            <div className="flex flex-col justify-between p-6" style={{ background: '#1c1b1b' }}>
-              <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>CURRENT ROUND</span>
-              <div className="flex items-end gap-2">
-                <span style={{ fontWeight: 700, fontSize: 48, lineHeight: '48px', color: '#e5e2e1' }}>03</span>
-                <span style={{ fontSize: 18, color: '#aa8984', paddingBottom: 6 }}>/ 05</span>
-              </div>
-              <span style={{ fontSize: 10, color: '#aa8984', opacity: 0.6 }}>REMAINING PUZZLES: 2</span>
-            </div>
-
-            <div className="flex items-center justify-center p-6 relative" style={{ background: '#0e0e0e' }}>
-              <span style={{ position: 'absolute', top: 8, right: 8, fontSize: 8, color: '#aa8984', opacity: 0.4 }}>AUTH_QR_SCAN</span>
-              <div style={{ width: 96, height: 96, background: 'rgba(255,255,255,0.8)' }} />
-            </div>
-          </div>
-
-          {/* Operative Manifest */}
-          <div style={{ background: '#1c1b1b' }}>
-            <div className="flex items-center justify-between px-6 py-4" style={{ borderBottom: '1px solid #353534' }}>
-              <div className="flex items-center gap-3">
-                <div style={{ width: 4, height: 16, background: '#8b0000' }} />
-                <span style={{ fontWeight: 700, fontSize: 14, letterSpacing: '1.4px', color: '#e5e2e1' }}>OPERATIVE_MANIFEST</span>
-              </div>
-              <div className="flex items-center gap-4">
-                <div className="flex items-center gap-1">
-                  <CheckIcon />
-                  <span style={{ fontSize: 10, color: '#aa8984' }}>SOLVED</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <CrossIcon />
-                  <span style={{ fontSize: 10, color: '#aa8984' }}>IN PROGRESS</span>
-                </div>
-              </div>
-            </div>
-
-            <div className="flex items-center px-6 py-3" style={{ background: '#0e0e0e', borderBottom: '1px solid #353534' }}>
-              <div style={{ width: 160, fontSize: 10, fontWeight: 700, letterSpacing: '1px', color: '#aa8984' }}>PLAYER</div>
-              {[1, 2, 3, 4, 5].map(n => (
-                <div key={n} style={{ flex: 1, fontSize: 10, fontWeight: 700, letterSpacing: '1px', color: '#aa8984', textAlign: 'center' }}>PUZZLE {n}</div>
-              ))}
-              <div style={{ width: 120, fontSize: 10, fontWeight: 700, letterSpacing: '1px', color: '#aa8984', textAlign: 'right' }}>STATUS</div>
-            </div>
-
-            {players.map((player, i) => {
-              const data = MOCK_PUZZLE_DATA[i] || { puzzles: [false, false, false, false, false], status: 'NEEDS HELP' };
-              const isCompleted = data.status === 'COMPLETED';
-              return (
-                <div key={player.id} className="flex items-center px-6 py-4" style={{ borderTop: i > 0 ? '1px solid #353534' : 'none' }}>
-                  <div style={{ width: 160, fontWeight: 700, fontSize: 12, color: '#e5e2e1' }}>{player.name.toUpperCase()}</div>
-                  {data.puzzles.map((solved, pi) => (
-                    <div key={pi} style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-                      {solved ? <CheckIcon /> : pi < 3 ? <CrossIcon /> : null}
-                    </div>
-                  ))}
-                  <div style={{ width: 120, display: 'flex', justifyContent: 'flex-end' }}>
-                    <span style={{
-                      fontSize: 9,
-                      padding: '2px 8px',
-                      background: isCompleted ? '#474747' : '#93000a',
-                      color: isCompleted ? '#e5e2e1' : '#ffdad6',
-                    }}>
-                      {data.status}
-                    </span>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          {/* Event Log */}
-          <div className="p-6" style={{ background: '#0e0e0e', borderLeft: '1px solid rgba(90,64,60,0.2)' }}>
-            <div className="flex items-center gap-3 mb-4">
-              <div style={{ width: 4, height: 16, background: '#8b0000' }} />
-              <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>EVENT_LOG</span>
-            </div>
-            <div className="flex flex-col gap-4">
-              {MOCK_EVENTS.map((event, i) => (
-                <div key={i} className="flex items-start gap-4 pl-3 py-1" style={{ borderLeft: `1px solid ${event.highlight ? '#8b0000' : 'rgba(90,64,60,0.3)'}` }}>
-                  <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 11, color: '#aa8984', whiteSpace: 'nowrap' }}>[ {event.time} ]</span>
-                  <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 11, color: event.highlight ? '#e5e2e1' : '#e3beb8' }}>{event.message}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-
+      {/* Header */}
+      <header className="flex items-center justify-between px-6 py-4" style={{ background: '#131313', borderBottom: '2px solid #1c1b1b' }}>
+        <div className="flex items-center gap-4">
+          <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1' }}>ESCAPESNAP</span>
+          <div style={{ width: 1, height: 16, background: '#5a403c', opacity: 0.3 }} />
         </div>
-      </section>
-    </main>
+      </header>
+
+      {/* Body */}
+      <div className="flex-1 p-8 flex flex-col gap-8">
+
+        {/* Stats row */}
+        <div className="grid grid-cols-4" style={{ height: 160 }}>
+          <div className="flex flex-col justify-between p-6" style={{ background: '#0e0e0e', borderLeft: `2px solid ${isExpired ? '#ff0000' : '#8b0000'}` }}>
+            <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>TIME REMAINING</span>
+            <span style={{ fontWeight: 300, fontSize: 60, letterSpacing: '-3px', lineHeight: '60px', color: isExpired ? '#ff4444' : '#e5e2e1' }}>
+              {game.startedAt ? formatTime(timeLeft) : '--:--'}
+            </span>
+            {!game.startedAt && (
+              <span style={{ fontSize: 9, color: '#aa8984', opacity: 0.6, letterSpacing: '0.5px' }}>GAME NOT STARTED</span>
+            )}
+          </div>
+
+          <div className="flex flex-col justify-between p-6" style={{ background: '#1c1b1b' }}>
+            <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>TEAM PROGRESS</span>
+            <div className="flex items-end gap-2">
+              <span style={{ fontWeight: 700, fontSize: 48, lineHeight: '48px', color: '#e5e2e1' }}>64</span>
+              <span style={{ fontSize: 24, color: '#aa8984', paddingBottom: 4 }}>%</span>
+            </div>
+            <div style={{ height: 4, background: '#353534' }}>
+              <div style={{ height: '100%', width: '64%', background: '#8b0000' }} />
+            </div>
+          </div>
+
+          <div className="flex flex-col justify-between p-6" style={{ background: '#1c1b1b' }}>
+            <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>CURRENT ROUND</span>
+            <div className="flex items-end gap-2">
+              <span style={{ fontWeight: 700, fontSize: 48, lineHeight: '48px', color: '#e5e2e1' }}>03</span>
+              <span style={{ fontSize: 18, color: '#aa8984', paddingBottom: 6 }}>/ 05</span>
+            </div>
+            <span style={{ fontSize: 10, color: '#aa8984', opacity: 0.6 }}>REMAINING PUZZLES: 2</span>
+          </div>
+
+          <div className="flex items-center justify-center p-6 relative" style={{ background: '#0e0e0e' }}>
+            <span style={{ position: 'absolute', top: 8, right: 8, fontSize: 8, color: '#aa8984', opacity: 0.4 }}>AUTH_QR_SCAN</span>
+            <div style={{ width: 96, height: 96, background: 'rgba(255,255,255,0.8)' }} />
+          </div>
+        </div>
+
+        {/* Operative Manifest */}
+        <div style={{ background: '#1c1b1b' }}>
+          <div className="flex items-center justify-between px-6 py-4" style={{ borderBottom: '1px solid #353534' }}>
+            <div className="flex items-center gap-3">
+              <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+              <span style={{ fontWeight: 700, fontSize: 14, letterSpacing: '1.4px', color: '#e5e2e1' }}>OPERATIVE_MANIFEST</span>
+            </div>
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-1">
+                <CheckIcon />
+                <span style={{ fontSize: 10, color: '#aa8984' }}>SOLVED</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <CrossIcon />
+                <span style={{ fontSize: 10, color: '#aa8984' }}>IN PROGRESS</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center px-6 py-3" style={{ background: '#0e0e0e', borderBottom: '1px solid #353534' }}>
+            <div style={{ width: 160, fontSize: 10, fontWeight: 700, letterSpacing: '1px', color: '#aa8984' }}>PLAYER</div>
+            {[1, 2, 3, 4, 5].map(n => (
+              <div key={n} style={{ flex: 1, fontSize: 10, fontWeight: 700, letterSpacing: '1px', color: '#aa8984', textAlign: 'center' }}>PUZZLE {n}</div>
+            ))}
+            <div style={{ width: 120, fontSize: 10, fontWeight: 700, letterSpacing: '1px', color: '#aa8984', textAlign: 'right' }}>STATUS</div>
+          </div>
+
+          {players.map((player, i) => {
+            const data = MOCK_PUZZLE_DATA[i] || { puzzles: [false, false, false, false, false], status: 'NEEDS HELP' };
+            const isCompleted = data.status === 'COMPLETED';
+            return (
+              <div key={player.id} className="flex items-center px-6 py-4" style={{ borderTop: i > 0 ? '1px solid #353534' : 'none' }}>
+                <div style={{ width: 160, fontWeight: 700, fontSize: 12, color: '#e5e2e1' }}>{player.name.toUpperCase()}</div>
+                {data.puzzles.map((solved, pi) => (
+                  <div key={pi} style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                    {solved ? <CheckIcon /> : pi < 3 ? <CrossIcon /> : null}
+                  </div>
+                ))}
+                <div style={{ width: 120, display: 'flex', justifyContent: 'flex-end' }}>
+                  <span style={{
+                    fontSize: 9,
+                    padding: '2px 8px',
+                    background: isCompleted ? '#474747' : '#93000a',
+                    color: isCompleted ? '#e5e2e1' : '#ffdad6',
+                  }}>
+                    {data.status}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Event Log */}
+        <div className="p-6" style={{ background: '#0e0e0e', borderLeft: '1px solid rgba(90,64,60,0.2)' }}>
+          <div className="flex items-center gap-3 mb-4">
+            <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+            <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>EVENT_LOG</span>
+          </div>
+          <div className="flex flex-col gap-4">
+            {MOCK_EVENTS.map((event, i) => (
+              <div key={i} className="flex items-start gap-4 pl-3 py-1" style={{ borderLeft: `1px solid ${event.highlight ? '#8b0000' : 'rgba(90,64,60,0.3)'}` }}>
+                <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 11, color: '#aa8984', whiteSpace: 'nowrap' }}>[ {event.time} ]</span>
+                <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 11, color: event.highlight ? '#e5e2e1' : '#e3beb8' }}>{event.message}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+      </div>
+
+    </SidebarLayout>
   );
 };
 

--- a/imports/ui/host/pages/progress/ProgressPage.jsx
+++ b/imports/ui/host/pages/progress/ProgressPage.jsx
@@ -222,26 +222,6 @@ const ProgressPage = () => {
             <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1' }}>ESCAPESNAP</span>
             <div style={{ width: 1, height: 16, background: '#5a403c', opacity: 0.3 }} />
           </div>
-          <div className="flex items-center gap-3">
-            <div className="flex items-center gap-2 px-3 py-1" style={{ background: '#0e0e0e', border: '1px solid rgba(90,64,60,0.1)' }}>
-              <span style={{ fontSize: 10, color: '#aa8984' }}>PIN:</span>
-              <span style={{ fontWeight: 700, fontSize: 14, letterSpacing: '1.4px', color: '#e5e2e1' }}>{pin}</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <circle cx="9" cy="9" r="7" stroke="#aa8984" strokeWidth="1.5" />
-                <polyline points="9,5 9,9 12,11" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <circle cx="9" cy="6" r="3" stroke="#aa8984" strokeWidth="1.5" />
-                <path d="M3 16c0-3.314 2.686-6 6-6s6 2.686 6 6" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
-              </svg>
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <path d="M9 2C6.24 2 4 4.24 4 7v5l-1.5 1.5V15h13v-1.5L14 12V7c0-2.76-2.24-5-5-5z" stroke="#aa8984" strokeWidth="1.5" strokeLinejoin="round" />
-                <path d="M7 15a2 2 0 004 0" stroke="#aa8984" strokeWidth="1.5" />
-              </svg>
-            </div>
-          </div>
         </header>
 
         {/* Body */}

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -1,39 +1,188 @@
 import React, { useState } from 'react';
-import { useParams } from 'react-router';
+import { useParams, useNavigate } from 'react-router';
 import { useFinalRiddle } from '/imports/ui/shared/hooks/useFinalRiddle.js';
 import { useRevealedLetters } from '/imports/ui/shared/hooks/useRevealedLetters.js';
-import { useNavigate } from 'react-router';
-
 import GameNotFound from '/imports/ui/shared/components/GameNotFound.jsx';
-import RevealedLetters from '/imports/ui/host/components/riddle/RevealedLetters.jsx';
-import FinalRiddle from '/imports/ui/host/components/riddle/FinalRiddle.jsx';
-import FinalRiddleInput from '/imports/ui/host/components/riddle/FinalRiddleInput.jsx';
 import WinScreen from '/imports/ui/host/pages/game-completion/WinScreen.jsx';
+import FinalRiddleInput from '/imports/ui/host/components/riddle/FinalRiddleInput.jsx';
+
+const HamburgerIcon = () => (
+  <svg width="18" height="14" viewBox="0 0 18 14" fill="none" style={{ flexShrink: 0 }}>
+    <line x1="0" y1="1" x2="18" y2="1" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="0" y1="7" x2="18" y2="7" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="0" y1="13" x2="18" y2="13" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const OperativesIcon = ({ color }) => (
+  <svg width="19" height="20" viewBox="0 0 19 20" fill="none" style={{ flexShrink: 0 }}>
+    <circle cx="9.5" cy="10" r="8" stroke={color} strokeWidth="1.5" />
+    <circle cx="9.5" cy="10" r="3" stroke={color} strokeWidth="1.5" />
+    <line x1="9.5" y1="1" x2="9.5" y2="4" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="9.5" y1="16" x2="9.5" y2="19" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="1" y1="10" x2="4" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    <line x1="15" y1="10" x2="18" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const RiddleIcon = ({ color }) => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ flexShrink: 0 }}>
+    <path d="M9 1L11.5 6.5L17 7.3L13 11.2L14 17L9 14.3L4 17L5 11.2L1 7.3L6.5 6.5L9 1Z" stroke={color} strokeWidth="1.5" strokeLinejoin="round" />
+  </svg>
+);
+
+const Sidebar = ({ gameId, expanded, onToggle }) => {
+  const navigate = useNavigate();
+
+  const navItems = [
+    { label: 'OPERATIVES', Icon: OperativesIcon, route: `/game/${gameId}/progress`, active: false },
+    { label: 'FINAL RIDDLE', Icon: RiddleIcon, route: `/game/${gameId}/final-riddle`, active: true },
+  ];
+
+  return (
+    <aside style={{
+      width: expanded ? 200 : 60,
+      minHeight: '100vh',
+      background: '#0e0e0e',
+      borderRight: '1px solid #1c1b1b',
+      display: 'flex',
+      flexDirection: 'column',
+      transition: 'width 0.25s ease',
+      overflow: 'hidden',
+      flexShrink: 0,
+    }}>
+      <div style={{ borderBottom: '1px solid #1c1b1b', display: 'flex', alignItems: 'center', justifyContent: expanded ? 'space-between' : 'center', padding: expanded ? '20px 16px 20px 24px' : '20px 0' }}>
+        {expanded && (
+          <div>
+            <div style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1', whiteSpace: 'nowrap' }}>GAME</div>
+            <div style={{ fontWeight: 500, fontSize: 10, letterSpacing: '0.5px', color: '#8b0000', marginTop: 2, whiteSpace: 'nowrap' }}>FINAL RIDDLE</div>
+          </div>
+        )}
+        <button onClick={onToggle} title={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
+          style={{ background: 'transparent', cursor: 'pointer', opacity: 0.5, padding: 4, display: 'flex', alignItems: 'center' }}>
+          <HamburgerIcon />
+        </button>
+      </div>
+
+      <nav style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        {navItems.map(({ label, Icon, route, active }) => (
+          <button key={label} onClick={() => route && navigate(route)} title={!expanded ? label : undefined}
+            style={{
+              display: 'flex', alignItems: 'center',
+              gap: expanded ? 16 : 0,
+              justifyContent: expanded ? 'flex-start' : 'center',
+              padding: expanded ? '16px 24px' : '16px 0',
+              background: active ? '#1c1b1b' : 'transparent',
+              borderLeft: active ? '2px solid #8b0000' : '2px solid transparent',
+              cursor: 'pointer', opacity: active ? 1 : 0.7,
+              width: '100%', textAlign: 'left', transition: 'background 0.15s',
+            }}>
+            <Icon color={active ? '#e5e2e1' : '#aa8984'} />
+            {expanded && (
+              <span style={{ fontSize: 16, fontWeight: 500, letterSpacing: '0.8px', color: active ? '#e5e2e1' : '#aa8984', whiteSpace: 'nowrap' }}>
+                {label}
+              </span>
+            )}
+          </button>
+        ))}
+      </nav>
+    </aside>
+  );
+};
 
 const FinalRiddlePage = () => {
   const { gameId } = useParams();
-  const { loading, finalRiddle, gameStatus } = useFinalRiddle(gameId);
-  const { lettersLoading, letters } = useRevealedLetters(gameId);
+  const navigate = useNavigate();
+  const [sidebarExpanded, setSidebarExpanded] = useState(true);
   const [hasWon, setHasWon] = useState(false);
 
-  const navigate = useNavigate();
+  const { loading, finalRiddle } = useFinalRiddle(gameId);
+  const { lettersLoading, letters } = useRevealedLetters(gameId);
 
-  if (loading || lettersLoading) return <div className='min-h-screen flex items-center justify-center'>
-                            <span className="loading loading-spinner text-red-500"></span>
-                        </div>;
+  if (loading || lettersLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: '#131313' }}>
+        <p style={{ color: '#aa8984', fontSize: 10, letterSpacing: '1px' }}>LOADING...</p>
+      </div>
+    );
+  }
+
   if (!finalRiddle) return <GameNotFound />;
-  if (gameStatus !== 'final_riddle')
-    return <p className="text-red-500">Not in final riddle phase.</p>;
 
   if (hasWon) return <WinScreen onPlayAgain={() => navigate('/game/create')} />;
 
   return (
-      <div className='min-h-screen bg-gray-900'>
-        <FinalRiddle finalRiddle={finalRiddle} />
-          <RevealedLetters letters={letters} />
-          <FinalRiddleInput gameId={gameId} onCorrect={() => setHasWon(true)} />
+    <main className="flex min-h-screen" style={{ background: '#131313', color: '#e5e2e1', fontFamily: "'Space Grotesk', Helvetica, sans-serif" }}>
+
+      <Sidebar gameId={gameId} expanded={sidebarExpanded} onToggle={() => setSidebarExpanded(v => !v)} />
+
+      <section className="flex flex-col flex-1" style={{ minWidth: 0 }}>
+
+        {/* Header */}
+        <header className="flex items-center justify-between px-6 py-4" style={{ background: '#131313', borderBottom: '2px solid #1c1b1b' }}>
+          <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1' }}>ESCAPESNAP</span>
+        </header>
+
+        {/* Body */}
+        <div className="flex-1 p-8 flex flex-col gap-6">
+
+          {/* Title */}
+          <div className="flex items-center gap-3">
+            <div style={{ width: 4, height: 32, background: '#8b0000' }} />
+            <div>
+              <p style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>MISSION CRITICAL</p>
+              <h1 style={{ fontWeight: 700, fontSize: 28, letterSpacing: '2px', color: '#e5e2e1', lineHeight: 1.2 }}>
+                THE FINAL <span style={{ color: '#8b0000' }}>RIDDLE</span>
+              </h1>
+            </div>
+          </div>
+
+          {/* Riddle card */}
+          <div style={{ background: '#0e0e0e', borderLeft: '4px solid #8b0000', padding: '32px' }}>
+            <p style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984', marginBottom: 12 }}>DECRYPT THE CLUE</p>
+            <p style={{ fontSize: 22, fontWeight: 600, color: '#e5e2e1', lineHeight: 1.6, letterSpacing: '0.5px' }}>
+              "{finalRiddle}"
+            </p>
+          </div>
+
+          {/* Revealed Letters */}
+          <div style={{ background: '#1c1b1b', padding: '24px' }}>
+            <div className="flex items-center gap-3 mb-4">
+              <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+              <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>REVEALED LETTERS</span>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              {letters.map((letter, i) => (
+                <div key={i} style={{
+                  width: 64, height: 64,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  background: '#0e0e0e',
+                  borderBottom: '2px solid #8b0000',
+                  fontWeight: 700, fontSize: 24,
+                  color: '#e5e2e1', letterSpacing: '2px',
+                }}>
+                  {letter}
+                </div>
+              ))}
+              {letters.length === 0 && (
+                <p style={{ fontSize: 11, color: '#aa8984', opacity: 0.6 }}>NO LETTERS REVEALED YET</p>
+              )}
+            </div>
+          </div>
+
+          {/* Input */}
+          <div style={{ background: '#0e0e0e', padding: '24px' }}>
+            <div className="flex items-center gap-3 mb-4">
+              <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+              <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>SUBMIT ANSWER</span>
+            </div>
+            <FinalRiddleInput gameId={gameId} onCorrect={() => setHasWon(true)} />
+          </div>
+
         </div>
-    );
+      </section>
+    </main>
+  );
 };
 
 export default FinalRiddlePage;

--- a/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
+++ b/imports/ui/host/pages/riddle/FinalRiddlePage.jsx
@@ -5,95 +5,11 @@ import { useRevealedLetters } from '/imports/ui/shared/hooks/useRevealedLetters.
 import GameNotFound from '/imports/ui/shared/components/GameNotFound.jsx';
 import WinScreen from '/imports/ui/host/pages/game-completion/WinScreen.jsx';
 import FinalRiddleInput from '/imports/ui/host/components/riddle/FinalRiddleInput.jsx';
-
-const HamburgerIcon = () => (
-  <svg width="18" height="14" viewBox="0 0 18 14" fill="none" style={{ flexShrink: 0 }}>
-    <line x1="0" y1="1" x2="18" y2="1" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="0" y1="7" x2="18" y2="7" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="0" y1="13" x2="18" y2="13" stroke="#aa8984" strokeWidth="1.5" strokeLinecap="round" />
-  </svg>
-);
-
-const OperativesIcon = ({ color }) => (
-  <svg width="19" height="20" viewBox="0 0 19 20" fill="none" style={{ flexShrink: 0 }}>
-    <circle cx="9.5" cy="10" r="8" stroke={color} strokeWidth="1.5" />
-    <circle cx="9.5" cy="10" r="3" stroke={color} strokeWidth="1.5" />
-    <line x1="9.5" y1="1" x2="9.5" y2="4" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="9.5" y1="16" x2="9.5" y2="19" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="1" y1="10" x2="4" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
-    <line x1="15" y1="10" x2="18" y2="10" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
-  </svg>
-);
-
-const RiddleIcon = ({ color }) => (
-  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ flexShrink: 0 }}>
-    <path d="M9 1L11.5 6.5L17 7.3L13 11.2L14 17L9 14.3L4 17L5 11.2L1 7.3L6.5 6.5L9 1Z" stroke={color} strokeWidth="1.5" strokeLinejoin="round" />
-  </svg>
-);
-
-const Sidebar = ({ gameId, expanded, onToggle }) => {
-  const navigate = useNavigate();
-
-  const navItems = [
-    { label: 'OPERATIVES', Icon: OperativesIcon, route: `/game/${gameId}/progress`, active: false },
-    { label: 'FINAL RIDDLE', Icon: RiddleIcon, route: `/game/${gameId}/final-riddle`, active: true },
-  ];
-
-  return (
-    <aside style={{
-      width: expanded ? 200 : 60,
-      minHeight: '100vh',
-      background: '#0e0e0e',
-      borderRight: '1px solid #1c1b1b',
-      display: 'flex',
-      flexDirection: 'column',
-      transition: 'width 0.25s ease',
-      overflow: 'hidden',
-      flexShrink: 0,
-    }}>
-      <div style={{ borderBottom: '1px solid #1c1b1b', display: 'flex', alignItems: 'center', justifyContent: expanded ? 'space-between' : 'center', padding: expanded ? '20px 16px 20px 24px' : '20px 0' }}>
-        {expanded && (
-          <div>
-            <div style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1', whiteSpace: 'nowrap' }}>GAME</div>
-            <div style={{ fontWeight: 500, fontSize: 10, letterSpacing: '0.5px', color: '#8b0000', marginTop: 2, whiteSpace: 'nowrap' }}>FINAL RIDDLE</div>
-          </div>
-        )}
-        <button onClick={onToggle} title={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
-          style={{ background: 'transparent', cursor: 'pointer', opacity: 0.5, padding: 4, display: 'flex', alignItems: 'center' }}>
-          <HamburgerIcon />
-        </button>
-      </div>
-
-      <nav style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
-        {navItems.map(({ label, Icon, route, active }) => (
-          <button key={label} onClick={() => route && navigate(route)} title={!expanded ? label : undefined}
-            style={{
-              display: 'flex', alignItems: 'center',
-              gap: expanded ? 16 : 0,
-              justifyContent: expanded ? 'flex-start' : 'center',
-              padding: expanded ? '16px 24px' : '16px 0',
-              background: active ? '#1c1b1b' : 'transparent',
-              borderLeft: active ? '2px solid #8b0000' : '2px solid transparent',
-              cursor: 'pointer', opacity: active ? 1 : 0.7,
-              width: '100%', textAlign: 'left', transition: 'background 0.15s',
-            }}>
-            <Icon color={active ? '#e5e2e1' : '#aa8984'} />
-            {expanded && (
-              <span style={{ fontSize: 16, fontWeight: 500, letterSpacing: '0.8px', color: active ? '#e5e2e1' : '#aa8984', whiteSpace: 'nowrap' }}>
-                {label}
-              </span>
-            )}
-          </button>
-        ))}
-      </nav>
-    </aside>
-  );
-};
+import SidebarLayout from '/imports/ui/host/layouts/SidebarLayout.jsx';
 
 const FinalRiddlePage = () => {
   const { gameId } = useParams();
   const navigate = useNavigate();
-  const [sidebarExpanded, setSidebarExpanded] = useState(true);
   const [hasWon, setHasWon] = useState(false);
 
   const { loading, finalRiddle } = useFinalRiddle(gameId);
@@ -112,76 +28,72 @@ const FinalRiddlePage = () => {
   if (hasWon) return <WinScreen onPlayAgain={() => navigate('/game/create')} />;
 
   return (
-    <main className="flex min-h-screen" style={{ background: '#131313', color: '#e5e2e1', fontFamily: "'Space Grotesk', Helvetica, sans-serif" }}>
+    <SidebarLayout gameId={gameId} activePage="final-riddle">
 
-      <Sidebar gameId={gameId} expanded={sidebarExpanded} onToggle={() => setSidebarExpanded(v => !v)} />
+      {/* Header */}
+      <header className="flex items-center justify-between px-6 py-4" style={{ background: '#131313', borderBottom: '2px solid #1c1b1b' }}>
+        <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1' }}>ESCAPESNAP</span>
+      </header>
 
-      <section className="flex flex-col flex-1" style={{ minWidth: 0 }}>
+      {/* Body */}
+      <div className="flex-1 p-8 flex flex-col gap-6">
 
-        {/* Header */}
-        <header className="flex items-center justify-between px-6 py-4" style={{ background: '#131313', borderBottom: '2px solid #1c1b1b' }}>
-          <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '1.8px', color: '#e5e2e1' }}>ESCAPESNAP</span>
-        </header>
-
-        {/* Body */}
-        <div className="flex-1 p-8 flex flex-col gap-6">
-
-          {/* Title */}
-          <div className="flex items-center gap-3">
-            <div style={{ width: 4, height: 32, background: '#8b0000' }} />
-            <div>
-              <p style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>MISSION CRITICAL</p>
-              <h1 style={{ fontWeight: 700, fontSize: 28, letterSpacing: '2px', color: '#e5e2e1', lineHeight: 1.2 }}>
-                THE FINAL <span style={{ color: '#8b0000' }}>RIDDLE</span>
-              </h1>
-            </div>
+        {/* Title */}
+        <div className="flex items-center gap-3">
+          <div style={{ width: 4, height: 32, background: '#8b0000' }} />
+          <div>
+            <p style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>MISSION CRITICAL</p>
+            <h1 style={{ fontWeight: 700, fontSize: 28, letterSpacing: '2px', color: '#e5e2e1', lineHeight: 1.2 }}>
+              THE FINAL <span style={{ color: '#8b0000' }}>RIDDLE</span>
+            </h1>
           </div>
-
-          {/* Riddle card */}
-          <div style={{ background: '#0e0e0e', borderLeft: '4px solid #8b0000', padding: '32px' }}>
-            <p style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984', marginBottom: 12 }}>DECRYPT THE CLUE</p>
-            <p style={{ fontSize: 22, fontWeight: 600, color: '#e5e2e1', lineHeight: 1.6, letterSpacing: '0.5px' }}>
-              "{finalRiddle}"
-            </p>
-          </div>
-
-          {/* Revealed Letters */}
-          <div style={{ background: '#1c1b1b', padding: '24px' }}>
-            <div className="flex items-center gap-3 mb-4">
-              <div style={{ width: 4, height: 16, background: '#8b0000' }} />
-              <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>REVEALED LETTERS</span>
-            </div>
-            <div className="flex flex-wrap gap-3">
-              {letters.map((letter, i) => (
-                <div key={i} style={{
-                  width: 64, height: 64,
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  background: '#0e0e0e',
-                  borderBottom: '2px solid #8b0000',
-                  fontWeight: 700, fontSize: 24,
-                  color: '#e5e2e1', letterSpacing: '2px',
-                }}>
-                  {letter}
-                </div>
-              ))}
-              {letters.length === 0 && (
-                <p style={{ fontSize: 11, color: '#aa8984', opacity: 0.6 }}>NO LETTERS REVEALED YET</p>
-              )}
-            </div>
-          </div>
-
-          {/* Input */}
-          <div style={{ background: '#0e0e0e', padding: '24px' }}>
-            <div className="flex items-center gap-3 mb-4">
-              <div style={{ width: 4, height: 16, background: '#8b0000' }} />
-              <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>SUBMIT ANSWER</span>
-            </div>
-            <FinalRiddleInput gameId={gameId} onCorrect={() => setHasWon(true)} />
-          </div>
-
         </div>
-      </section>
-    </main>
+
+        {/* Riddle card */}
+        <div style={{ background: '#0e0e0e', borderLeft: '4px solid #8b0000', padding: '32px' }}>
+          <p style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984', marginBottom: 12 }}>DECRYPT THE CLUE</p>
+          <p style={{ fontSize: 22, fontWeight: 600, color: '#e5e2e1', lineHeight: 1.6, letterSpacing: '0.5px' }}>
+            "{finalRiddle}"
+          </p>
+        </div>
+
+        {/* Revealed Letters */}
+        <div style={{ background: '#1c1b1b', padding: '24px' }}>
+          <div className="flex items-center gap-3 mb-4">
+            <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+            <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>REVEALED LETTERS</span>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            {letters.map((letter, i) => (
+              <div key={i} style={{
+                width: 64, height: 64,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                background: '#0e0e0e',
+                borderBottom: '2px solid #8b0000',
+                fontWeight: 700, fontSize: 24,
+                color: '#e5e2e1', letterSpacing: '2px',
+              }}>
+                {letter}
+              </div>
+            ))}
+            {letters.length === 0 && (
+              <p style={{ fontSize: 11, color: '#aa8984', opacity: 0.6 }}>NO LETTERS REVEALED YET</p>
+            )}
+          </div>
+        </div>
+
+        {/* Input */}
+        <div style={{ background: '#0e0e0e', padding: '24px' }}>
+          <div className="flex items-center gap-3 mb-4">
+            <div style={{ width: 4, height: 16, background: '#8b0000' }} />
+            <span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '1.2px', color: '#e5e2e1' }}>SUBMIT ANSWER</span>
+          </div>
+          <FinalRiddleInput gameId={gameId} onCorrect={() => setHasWon(true)} />
+        </div>
+
+      </div>
+
+    </SidebarLayout>
   );
 };
 


### PR DESCRIPTION
## What does this PR do?
- Added collapsible sidebar to the Final Riddle page matching the Progress page style
- Restyled Final Riddle page to match the dark theme (#131313 background, red accents)
- Restyled the answer input and submit button to match the dark theme
- Sidebar now has OPERATIVES and FINAL RIDDLE nav items with working navigation between pages
- Removed status guard that was blocking navigation to the Final Riddle page
- made a limit of 3 guesses for the final reddle 

## Type of change
- [x] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Config / setup

## How to test
1. Create a game and start it from the lobby
2. On the progress page, click FINAL RIDDLE in the sidebar
3. Verify you land on the Final Riddle page with the dark theme
4. Verify the sidebar shows FINAL RIDDLE as active
5. Click OPERATIVES to navigate back to the progress page
6. Verify the sidebar collapse/expand button works on both pages

## Screenshot
<img width="1919" height="908" alt="image" src="https://github.com/user-attachments/assets/c3e3a05b-b712-41a0-81bc-0b5597521465" />

## Checklist
- [x] Code runs locally with no errors
- [x] Follows project folder structure
- [ ] No console.log left in code
- [ ] Lint passes (meteor npm run lint)
