### PR TITLE
[RTE] [SCRUM-110] feat: wire round counter and team progress to real …

### DIFF
--- a/imports/ui/host/pages/progress/ProgressPage.jsx
+++ b/imports/ui/host/pages/progress/ProgressPage.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router';
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
 import { Games } from '../../../../api/games/GamesCollection';
+import { Rounds } from '../../../../api/rounds/RoundsCollection';
 import SidebarLayout from '/imports/ui/host/layouts/SidebarLayout.jsx';
 
 const MOCK_PUZZLE_DATA = [
@@ -35,11 +36,13 @@ const ProgressPage = () => {
   const { gameId } = useParams();
   const [timeLeft, setTimeLeft] = useState(null);
 
-  const { game, loading } = useTracker(() => {
-    const sub = Meteor.subscribe('games.current', gameId);
+  const { game, rounds, loading } = useTracker(() => {
+    const gameSub = Meteor.subscribe('games.current', gameId);
+    const roundsSub = Meteor.subscribe('rounds.forGame', gameId);
     return {
-      loading: !sub.ready(),
+      loading: !gameSub.ready() || !roundsSub.ready(),
       game: Games.findOne(gameId),
+      rounds: Rounds.find({ gameId }).fetch(),
     };
   }, [gameId]);
 
@@ -88,6 +91,11 @@ const ProgressPage = () => {
 
   const isExpired = timeLeft === 0;
 
+  // SCRUM-110: calculate team progress from real round data
+  const totalRoundDocs = rounds.length;
+  const solvedRounds = rounds.filter(r => r.status === 'correct').length;
+  const teamProgress = totalRoundDocs > 0 ? Math.round((solvedRounds / totalRoundDocs) * 100) : 0;
+
   return (
     <SidebarLayout gameId={gameId} activePage="progress">
 
@@ -114,24 +122,32 @@ const ProgressPage = () => {
             )}
           </div>
 
+          {/* SCRUM-110: wire team progress to real round data */}
           <div className="flex flex-col justify-between p-6" style={{ background: '#1c1b1b' }}>
             <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>TEAM PROGRESS</span>
             <div className="flex items-end gap-2">
-              <span style={{ fontWeight: 700, fontSize: 48, lineHeight: '48px', color: '#e5e2e1' }}>64</span>
+              <span style={{ fontWeight: 700, fontSize: 48, lineHeight: '48px', color: '#e5e2e1' }}>{teamProgress}</span>
               <span style={{ fontSize: 24, color: '#aa8984', paddingBottom: 4 }}>%</span>
             </div>
             <div style={{ height: 4, background: '#353534' }}>
-              <div style={{ height: '100%', width: '64%', background: '#8b0000' }} />
+              <div style={{ height: '100%', width: `${teamProgress}%`, background: '#8b0000' }} />
             </div>
           </div>
 
+          {/* SCRUM-110: wire round counter to real game state */}
           <div className="flex flex-col justify-between p-6" style={{ background: '#1c1b1b' }}>
             <span style={{ fontSize: 10, letterSpacing: '1px', color: '#aa8984' }}>CURRENT ROUND</span>
             <div className="flex items-end gap-2">
-              <span style={{ fontWeight: 700, fontSize: 48, lineHeight: '48px', color: '#e5e2e1' }}>03</span>
-              <span style={{ fontSize: 18, color: '#aa8984', paddingBottom: 6 }}>/ 05</span>
+              <span style={{ fontWeight: 700, fontSize: 48, lineHeight: '48px', color: '#e5e2e1' }}>
+                {String(game.currentRound).padStart(2, '0')}
+              </span>
+              <span style={{ fontSize: 18, color: '#aa8984', paddingBottom: 6 }}>
+                / {String(game.totalRounds).padStart(2, '0')}
+              </span>
             </div>
-            <span style={{ fontSize: 10, color: '#aa8984', opacity: 0.6 }}>REMAINING PUZZLES: 2</span>
+            <span style={{ fontSize: 10, color: '#aa8984', opacity: 0.6 }}>
+              REMAINING PUZZLES: {Math.max(0, game.totalRounds - game.currentRound)}
+            </span>
           </div>
 
           <div className="flex items-center justify-center p-6 relative" style={{ background: '#0e0e0e' }}>


### PR DESCRIPTION
## What does this PR do?
Wires the host progress page (`/game/{id}/progress`) to read real game data instead of hardcoded mock values.

Two fields are now reactive:
- **CURRENT ROUND** — reads `currentRound` / `totalRounds` from the game document (was hardcoded `03 / 05`)
- **TEAM PROGRESS %** — calculated from `(correct rounds / total rounds) * 100` (was hardcoded `64%`)

Page also subscribes to `rounds.forGame` so the % updates live as round statuses change.

Operative manifest grid + event log are still mock — out of scope for this PR.

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Config / setup

## How to test
1. `meteor` to start the app
2. Create a new game -> click START MISSION
3. Navigate to `/game/{id}/progress`
4. Verify CURRENT ROUND shows `01 / 03` (real values from schema defaults), not `03 / 05`
5. Verify TEAM PROGRESS shows `0%` (no rounds solved yet)

Optional live-update test via `meteor mongo`:
- `db.games.updateOne({_id: "your-game-id"}, {$set: {currentRound: 2}})` → counter updates to `02 / 03` without refresh
- Insert a round doc with the right `gameId` and `status: "correct"` -> team progress bar jumps up live

## Screenshots (if UI change)
<img width="2940" height="1912" alt="Screenshot 2026-05-18 at 5 43 09 pm" src="https://github.com/user-attachments/assets/80625f7e-8fe8-405f-a223-0213932d84e5" />
<img width="2940" height="1912" alt="Screenshot 2026-05-18 at 5 43 54 pm" src="https://github.com/user-attachments/assets/9a9d114f-b212-487d-a5b0-d2729eb3f252" />

## Checklist
- [x] Code runs locally with no errors
- [x] Follows project folder structure
- [ ] No console.log left in code
- [ ] Lint passes (meteor npm run lint)
